### PR TITLE
Add login page with navigation bar

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,5 +1,7 @@
-import type { Metadata } from "next";
-import "./globals.css";
+import type { Metadata } from 'next';
+import './globals.css';
+import { Providers } from '@/components/Providers';
+import { NavBar } from '@/components/NavBar';
 
 export const metadata: Metadata = {
   title: "Choose Your Own Curriculum",
@@ -13,7 +15,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <Providers>
+          <NavBar />
+          {children}
+        </Providers>
+      </body>
     </html>
   );
 }

--- a/app/src/app/login/page.tsx
+++ b/app/src/app/login/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { signIn } from 'next-auth/react';
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  container: { padding: '2rem', textAlign: 'center' },
+  button: {
+    backgroundColor: 'blue',
+    color: 'white',
+    padding: '0.5rem 1rem',
+    borderWidth: 0,
+    borderStyle: 'none',
+    cursor: 'pointer',
+  },
+});
+
+export default function LoginPage() {
+  return (
+    <div {...stylex.props(styles.container)}>
+      <h1>Login</h1>
+      <button {...stylex.props(styles.button)} onClick={() => signIn()}>
+        Sign in with Email
+      </button>
+    </div>
+  );
+}

--- a/app/src/components/NavBar.stories.tsx
+++ b/app/src/components/NavBar.stories.tsx
@@ -1,0 +1,9 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { NavBar } from './NavBar';
+
+const meta: Meta<typeof NavBar> = {
+  component: NavBar,
+};
+export default meta;
+
+export const Default: StoryObj<typeof NavBar> = {};

--- a/app/src/components/NavBar.test.tsx
+++ b/app/src/components/NavBar.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { NavBar } from './NavBar';
+import { vi } from 'vitest';
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null }),
+  signOut: vi.fn(),
+}));
+
+test('shows sign in link when not authenticated', () => {
+  render(<NavBar />);
+  expect(screen.getByText('Sign in')).toBeInTheDocument();
+});

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -1,0 +1,39 @@
+'use client';
+import Link from 'next/link';
+import { useSession, signOut } from 'next-auth/react';
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  bar: {
+    display: 'flex',
+    padding: '1rem',
+    backgroundColor: '#eee',
+    gap: '1rem',
+  },
+  spacer: { flexGrow: 1 },
+  link: { color: 'blue', textDecoration: 'none' },
+  button: {
+    backgroundColor: 'transparent',
+    borderWidth: 0,
+    borderStyle: 'none',
+    cursor: 'pointer',
+    color: 'blue',
+  },
+});
+
+export function NavBar() {
+  const { data: session } = useSession();
+  return (
+    <nav {...stylex.props(styles.bar)}>
+      <Link href="/" {...stylex.props(styles.link)}>Home</Link>
+      <div {...stylex.props(styles.spacer)} />
+      {session ? (
+        <button onClick={() => signOut()} {...stylex.props(styles.button)}>
+          Sign out
+        </button>
+      ) : (
+        <Link href="/login" {...stylex.props(styles.link)}>Sign in</Link>
+      )}
+    </nav>
+  );
+}

--- a/app/src/components/Providers.tsx
+++ b/app/src/components/Providers.tsx
@@ -1,0 +1,6 @@
+'use client';
+import { SessionProvider } from 'next-auth/react';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}


### PR DESCRIPTION
## Summary
- add `Providers` to wrap `SessionProvider`
- add `NavBar` component with sign in/out link
- include `NavBar` and provider in root layout
- create login page with sign in button
- add tests and Storybook story for `NavBar`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686af2178634832bb20941ce02b8ff1e