### PR TITLE
Add login page and nav bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ A web application for planning and tracking long term learning goals. Users defi
 - **Casbin** for access control
 - **GitHub Actions** build Docker images and push to GCR
 
+The app now includes a simple login page at `/login` and a navigation bar with a
+sign in/out button.
+
 ## Development
 
 ```bash

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { AppNavBar } from "@/components/AppNavBar";
 
 export const metadata: Metadata = {
   title: "Choose Your Own Curriculum",
@@ -13,7 +14,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <AppNavBar />
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/src/app/login/page.tsx
+++ b/app/src/app/login/page.tsx
@@ -1,0 +1,18 @@
+import * as stylex from '@stylexjs/stylex';
+import { LoginButton } from '@/components/LoginButton';
+
+const styles = stylex.create({
+  container: {
+    padding: '2rem',
+    textAlign: 'center',
+  },
+});
+
+export default function LoginPage() {
+  return (
+    <div {...stylex.props(styles.container)}>
+      <h1>Login</h1>
+      <LoginButton />
+    </div>
+  );
+}

--- a/app/src/components/AppNavBar.stories.tsx
+++ b/app/src/components/AppNavBar.stories.tsx
@@ -1,0 +1,11 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { AppNavBar } from './AppNavBar';
+
+const meta: Meta<typeof AppNavBar> = {
+  component: AppNavBar,
+};
+export default meta;
+
+type Story = StoryObj<typeof AppNavBar>;
+
+export const Default: Story = {};

--- a/app/src/components/AppNavBar.test.tsx
+++ b/app/src/components/AppNavBar.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { AppNavBar } from './AppNavBar';
+import { useSession } from 'next-auth/react';
+
+vi.mock('next-auth/react', () => {
+  return {
+    useSession: vi.fn(() => ({ data: null })),
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  };
+});
+
+test('shows sign in when not authenticated', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (useSession as any).mockReturnValue({ data: null });
+  render(<AppNavBar />);
+  expect(screen.getByText('Sign in')).toBeInTheDocument();
+});
+
+test('shows sign out when authenticated', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (useSession as any).mockReturnValue({ data: { user: { id: '1' } } });
+  render(<AppNavBar />);
+  expect(screen.getByText('Sign out')).toBeInTheDocument();
+});

--- a/app/src/components/AppNavBar.tsx
+++ b/app/src/components/AppNavBar.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import Link from 'next/link';
+import { useSession, signIn, signOut } from 'next-auth/react';
+
+const styles = stylex.create({
+  root: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '1rem',
+    backgroundColor: '#f0f0f0',
+  },
+  links: {
+    display: 'flex',
+    gap: '1rem',
+    alignItems: 'center',
+  },
+  link: {
+    textDecoration: 'none',
+    color: 'black',
+  },
+});
+
+export function AppNavBar() {
+  const sessionData = useSession();
+  const session = sessionData ? sessionData.data : null;
+
+  return (
+    <nav {...stylex.props(styles.root)}>
+      <div {...stylex.props(styles.links)}>
+        <Link href="/" {...stylex.props(styles.link)}>
+          Home
+        </Link>
+        <Link href="/login" {...stylex.props(styles.link)}>
+          Login
+        </Link>
+      </div>
+      {session ? (
+        <button onClick={() => signOut()}>Sign out</button>
+      ) : (
+        <button onClick={() => signIn()}>Sign in</button>
+      )}
+    </nav>
+  );
+}

--- a/app/src/components/LoginButton.stories.tsx
+++ b/app/src/components/LoginButton.stories.tsx
@@ -1,0 +1,11 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LoginButton } from './LoginButton';
+
+const meta: Meta<typeof LoginButton> = {
+  component: LoginButton,
+};
+export default meta;
+
+type Story = StoryObj<typeof LoginButton>;
+
+export const Default: Story = {};

--- a/app/src/components/LoginButton.test.tsx
+++ b/app/src/components/LoginButton.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { LoginButton } from './LoginButton';
+
+vi.mock('next-auth/react', () => ({ signIn: vi.fn() }));
+
+test('renders sign in button', () => {
+  render(<LoginButton />);
+  expect(screen.getByText('Sign in')).toBeInTheDocument();
+});

--- a/app/src/components/LoginButton.tsx
+++ b/app/src/components/LoginButton.tsx
@@ -1,0 +1,6 @@
+'use client';
+import { signIn } from 'next-auth/react';
+
+export function LoginButton() {
+  return <button onClick={() => signIn()}>Sign in</button>;
+}


### PR DESCRIPTION
## Summary
- create `AppNavBar` with sign in/out button using NextAuth
- add `LoginButton` component and `/login` page
- include nav bar in root layout
- document new login page in README
- add stories and tests for new components

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686af2178634832bb20941ce02b8ff1e