### PR TITLE
Add login page and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A web application for planning and tracking long term learning goals. Users define topic graphs and upload work samples. The app stores metadata and embeddings to recommend what to study next.
 
+Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**.
+
 ## Tech Stack
 
 - **Next.js** with React Server Components and Server Side Rendering

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import AuthProvider from "@/components/AuthProvider";
+import { NavBar } from "@/components/NavBar";
 
 export const metadata: Metadata = {
   title: "Choose Your Own Curriculum",
@@ -13,7 +15,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <AuthProvider>
+          <NavBar />
+          {children}
+        </AuthProvider>
+      </body>
     </html>
   );
 }

--- a/app/src/app/login/page.tsx
+++ b/app/src/app/login/page.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { signIn } from 'next-auth/react';
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  container: {
+    padding: '2rem',
+    textAlign: 'center',
+  },
+  button: {
+    padding: '0.5rem 1rem',
+    fontSize: '1rem',
+    cursor: 'pointer',
+  },
+});
+
+export default function LoginPage() {
+  return (
+    <div {...stylex.props(styles.container)}>
+      <h1>Log In</h1>
+      <button {...stylex.props(styles.button)} onClick={() => signIn()}>
+        Sign in with Email
+      </button>
+    </div>
+  );
+}

--- a/app/src/components/AuthProvider.stories.tsx
+++ b/app/src/components/AuthProvider.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import AuthProvider from './AuthProvider';
+
+const meta: Meta<typeof AuthProvider> = {
+  component: AuthProvider,
+};
+export default meta;
+
+type Story = StoryObj<typeof AuthProvider>;
+
+export const Default: Story = {
+  render: () => (
+    <AuthProvider>
+      <div>Content</div>
+    </AuthProvider>
+  ),
+};

--- a/app/src/components/AuthProvider.test.tsx
+++ b/app/src/components/AuthProvider.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import AuthProvider from './AuthProvider';
+
+vi.mock('next-auth/react', async () => {
+  const actual = (await vi.importActual<typeof import('next-auth/react')>('next-auth/react'));
+  return {
+    ...actual,
+    SessionProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  };
+});
+
+test('renders children', () => {
+  render(
+    <AuthProvider>
+      <span>child</span>
+    </AuthProvider>
+  );
+  expect(screen.getByText('child')).toBeInTheDocument();
+});

--- a/app/src/components/AuthProvider.tsx
+++ b/app/src/components/AuthProvider.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { SessionProvider } from 'next-auth/react';
+
+export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/app/src/components/NavBar.stories.tsx
+++ b/app/src/components/NavBar.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { NavBar } from './NavBar';
+import { SessionProvider } from 'next-auth/react';
+
+const meta: Meta<typeof NavBar> = {
+  component: NavBar,
+};
+export default meta;
+
+type Story = StoryObj<typeof NavBar>;
+
+export const LoggedOut: Story = {
+  render: () => (
+    <SessionProvider>
+      <NavBar />
+    </SessionProvider>
+  ),
+};
+
+export const LoggedIn: Story = {
+  render: () => (
+    <SessionProvider session={{
+      user: { name: 'Alice', email: 'alice@example.com' },
+      expires: '1',
+    }}>
+      <NavBar />
+    </SessionProvider>
+  ),
+};

--- a/app/src/components/NavBar.test.tsx
+++ b/app/src/components/NavBar.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { NavBar } from './NavBar';
+import { useSession } from 'next-auth/react';
+
+vi.mock('next-auth/react', async () => {
+  const actual = (await vi.importActual<typeof import('next-auth/react')>('next-auth/react'));
+  return {
+    ...actual,
+    useSession: vi.fn(),
+    signOut: vi.fn(),
+  };
+});
+const mockedUseSession = useSession as unknown as vi.Mock;
+
+test('shows sign in link when unauthenticated', () => {
+  mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+  render(<NavBar />);
+  expect(screen.getByText('Sign in')).toBeInTheDocument();
+});
+
+test('shows sign out when authenticated', () => {
+  mockedUseSession.mockReturnValue({ data: { user: { name: 'a' }, expires: '1' }, status: 'authenticated' });
+  render(<NavBar />);
+  expect(screen.getByText('Sign out')).toBeInTheDocument();
+});

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import Link from 'next/link';
+import { useSession, signOut } from 'next-auth/react';
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  bar: {
+    display: 'flex',
+    padding: '1rem',
+    backgroundColor: '#eee',
+    gap: '1rem',
+    alignItems: 'center',
+  },
+  link: {
+    textDecoration: 'none',
+    color: 'inherit',
+  },
+  spacer: {
+    flexGrow: 1,
+  },
+  button: {
+    backgroundColor: 'transparent',
+    borderWidth: 0,
+    cursor: 'pointer',
+    textDecoration: 'underline',
+    padding: 0,
+    font: 'inherit',
+    color: 'inherit',
+  },
+});
+
+export function NavBar() {
+  const { data: session } = useSession();
+  return (
+    <nav {...stylex.props(styles.bar)}>
+      <Link href="/" {...stylex.props(styles.link)}>
+        Home
+      </Link>
+      <div {...stylex.props(styles.spacer)} />
+      {session ? (
+        <button {...stylex.props(styles.button)} onClick={() => signOut()}>
+          Sign out
+        </button>
+      ) : (
+        <Link href="/login" {...stylex.props(styles.link)}>
+          Sign in
+        </Link>
+      )}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add an AuthProvider component
- add a NavBar with sign in/out support
- add login page
- show navigation in the root layout
- document login flow
- add tests and Storybook stories for new components

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686af2178634832bb20941ce02b8ff1e