### PR TITLE
Add math DAG generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A web application for planning and tracking long term learning goals. Users defi
 
 Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**.
 
+The home page includes a math skill selector that generates a mermaid DAG of prerequisites using the built-in LLM client.
+
 ## Tech Stack
 
 - **Next.js** with React Server Components and Server Side Rendering

--- a/app/src/app/api/generate-graph/route.ts
+++ b/app/src/app/api/generate-graph/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { LLMClient } from '@/llm/client';
+
+const bodySchema = z.object({ topics: z.array(z.string()) });
+
+export async function POST(req: NextRequest) {
+  const json = await req.json();
+  const { topics } = bodySchema.parse(json);
+  const client = new LLMClient(process.env.OPENAI_API_KEY || '');
+  const schema = z.object({ graph: z.string() });
+  const prompt = `Create a mermaid DAG showing a progression from kindergarten math to these topics: ${topics.join(', ')}. Include prerequisite links.`;
+  const result = await client.chat(prompt, {
+    systemPrompt: 'You are an expert math curriculum planner.',
+    schema,
+  });
+  if (result.error || !result.response) {
+    return NextResponse.json({ error: result.error?.message || 'error' }, { status: 500 });
+  }
+  return NextResponse.json({ graph: result.response.graph });
+}

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,4 +1,5 @@
 import * as stylex from '@stylexjs/stylex';
+import { MathSkillSelector } from '@/components/MathSkillSelector';
 
 const styles = stylex.create({
   container: {
@@ -11,7 +12,8 @@ export default function Home() {
   return (
     <div {...stylex.props(styles.container)}>
       <h1>Choose Your Own Curriculum</h1>
-      <p>Welcome! Scaffold under construction.</p>
+      <p>Select advanced math topics to see their prerequisites.</p>
+      <MathSkillSelector />
     </div>
   );
 }

--- a/app/src/components/MathSkillSelector.stories.tsx
+++ b/app/src/components/MathSkillSelector.stories.tsx
@@ -1,0 +1,11 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MathSkillSelector } from './MathSkillSelector';
+
+const meta: Meta<typeof MathSkillSelector> = {
+  component: MathSkillSelector,
+};
+export default meta;
+
+type Story = StoryObj<typeof MathSkillSelector>;
+
+export const Default: Story = {};

--- a/app/src/components/MathSkillSelector.test.tsx
+++ b/app/src/components/MathSkillSelector.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MathSkillSelector } from './MathSkillSelector';
+
+vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ graph: 'g' }) }));
+// provide dummy mermaid implementation
+(globalThis as Record<string, unknown>).mermaid = {
+  render: vi.fn(),
+  initialize: vi.fn(),
+};
+
+test('calls API with selected topics', async () => {
+  render(<MathSkillSelector />);
+  fireEvent.click(screen.getByLabelText('Algebra'));
+  fireEvent.click(screen.getByText('Generate Graph'));
+  expect(fetch).toHaveBeenCalledWith('/api/generate-graph', expect.objectContaining({ method: 'POST' }));
+});

--- a/app/src/components/MathSkillSelector.tsx
+++ b/app/src/components/MathSkillSelector.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useState, useEffect } from 'react';
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  container: { padding: '2rem' },
+  list: { display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: '0.25rem' },
+  button: { marginTop: '1rem', padding: '0.5rem 1rem', cursor: 'pointer' },
+  graph: { marginTop: '2rem', textAlign: 'left' },
+});
+
+const skills = [
+  'Algebra',
+  'Geometry',
+  'Trigonometry',
+  'Precalculus',
+  'Calculus',
+  'Linear Algebra',
+  'Differential Equations',
+  'Discrete Mathematics',
+  'Probability and Statistics',
+  'Real Analysis',
+  'Complex Analysis',
+  'Abstract Algebra',
+  'Topology',
+];
+
+export function MathSkillSelector() {
+  const [selected, setSelected] = useState<string[]>([]);
+  const [graph, setGraph] = useState('');
+
+  // Load mermaid from CDN once on mount
+  useEffect(() => {
+    if (document.getElementById('mermaid-script')) return;
+    const script = document.createElement('script');
+    script.id = 'mermaid-script';
+    script.src = 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js';
+    script.onload = () => {
+      const m = (window as unknown as { mermaid: { initialize: (opts: unknown) => void } }).mermaid;
+      m.initialize({ startOnLoad: false });
+    };
+    document.body.appendChild(script);
+  }, []);
+
+  useEffect(() => {
+    const m = (window as unknown as { mermaid?: { render: (id: string, code: string, cb: (svg: string) => void) => void } }).mermaid;
+    if (!graph || !m) return;
+    m.render('math-graph', graph, (svg: string) => {
+      const container = document.getElementById('graph-container');
+      if (container) container.innerHTML = svg;
+    });
+  }, [graph]);
+
+  const toggle = (skill: string) => {
+    setSelected((prev) =>
+      prev.includes(skill) ? prev.filter((s) => s !== skill) : [...prev, skill]
+    );
+  };
+
+  const generate = async () => {
+    const res = await fetch('/api/generate-graph', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ topics: selected }),
+    });
+    if (res.ok) {
+      const data = (await res.json()) as { graph: string };
+      setGraph(data.graph);
+    }
+  };
+
+  return (
+    <div {...stylex.props(styles.container)}>
+      <div {...stylex.props(styles.list)}>
+        {skills.map((skill) => (
+          <label key={skill}>
+            <input
+              type="checkbox"
+              checked={selected.includes(skill)}
+              onChange={() => toggle(skill)}
+            />{' '}
+            {skill}
+          </label>
+        ))}
+      </div>
+      <button {...stylex.props(styles.button)} onClick={generate}>
+        Generate Graph
+      </button>
+      {graph && <div id="graph-container" {...stylex.props(styles.graph)} />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add math skill selector component with mermaid DAG rendering
- add API route using the LLM client to generate the DAG
- insert math skill selector on the home page
- document math DAG feature in README
- include tests and stories for the new component

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686afa977104832bb2e5b279cc614d9b