### PR TITLE
Fix missing better-sqlite3 binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ nvm install 22
 nvm use 22
 ```
 
-After installing dependencies, run the following to compile native modules such
-as `better-sqlite3` for Node 22:
+
+`pnpm install` automatically rebuilds native modules like `better-sqlite3` for
+the current Node version. If you encounter binding errors, you can manually
+rebuild with:
 
 ```bash
 npm rebuild better-sqlite3

--- a/app/package.json
+++ b/app/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
+    "postinstall": "npm rebuild better-sqlite3",
     "storybook": "storybook dev -p 6006 --ci",
     "build-storybook": "storybook build"
   },


### PR DESCRIPTION
## Summary
- add a `postinstall` script to rebuild better-sqlite3
- clarify README about rebuilding native modules

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686affdc5960832baac18f3ac7f5ad65