### PR TITLE
Implement uploaded work feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ A web application for planning and tracking long term learning goals. Users defi
 
 Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**.
 
+Work samples can be uploaded from the **Upload Work** page. Each upload stores the
+document, summary, completion date, and embeddings generated with the
+`multimodal-embedding-3-small` model. Uploaded files are listed on the
+**Uploaded Work** page.
+
 The home page includes a math skill selector that generates a mermaid DAG of prerequisites using the built-in LLM client.
 
 ## Tech Stack

--- a/TASKS.md
+++ b/TASKS.md
@@ -5,7 +5,7 @@ This document tracks outstanding work for the Choose Your Own Curriculum project
 - **Authentication**: Implement user sign up and login using NextAuth or similar. The first registered user should be assigned the `superadmin` role.
 - **Profile Management**: Allow users to create student and teacher profiles and manage many-to-many relationships between students and teachers.
 - **Topic DAGs**: Provide CRUD interfaces to create and manage topic graphs expressed in Mermaid DAG format.
-- **Work Uploads**: Support uploading work samples, generating embeddings, and storing summaries in the database.
+- **Work Uploads**: ✅ Users can upload work samples with summaries and embeddings.
 - **Recommendations**: Combine topic DAGs and uploaded work to recommend what topics to study next.
 - **Multiple DAGs**: Allow each user to manage multiple DAGs and select one when generating lesson plans or quizzes.
 - **Casbin Access Control**: Apply Casbin policies across API routes to secure student/teacher interactions.

--- a/app/drizzle/0001_wet_penance.sql
+++ b/app/drizzle/0001_wet_penance.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `student` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `work_upload` (
+	`id` text PRIMARY KEY NOT NULL,
+	`student_id` text NOT NULL,
+	`uploaded_by_id` text NOT NULL,
+	`uploaded_at` integer NOT NULL,
+	`completed_at` integer,
+	`summary` text,
+	`embedding` text,
+	`file` blob,
+	FOREIGN KEY (`student_id`) REFERENCES `student`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`uploaded_by_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/app/drizzle/meta/0001_snapshot.json
+++ b/app/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,477 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "454b33c5-d018-4e5a-9aae-1eef1cd5bd3a",
+  "prevId": "69707633-8160-4cb7-8039-5099aedf0343",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "name": "account_provider_providerAccountId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authenticator": {
+      "name": "authenticator",
+      "columns": {
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialPublicKey": {
+          "name": "credentialPublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialDeviceType": {
+          "name": "credentialDeviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialBackedUp": {
+          "name": "credentialBackedUp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authenticator_credentialID_unique": {
+          "name": "authenticator_credentialID_unique",
+          "columns": [
+            "credentialID"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "authenticator_userId_user_id_fk": {
+          "name": "authenticator_userId_user_id_fk",
+          "tableFrom": "authenticator",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authenticator_userId_credentialID_pk": {
+          "columns": [
+            "userId",
+            "credentialID"
+          ],
+          "name": "authenticator_userId_credentialID_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "student": {
+      "name": "student",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verificationToken": {
+      "name": "verificationToken",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "columns": [
+            "identifier",
+            "token"
+          ],
+          "name": "verificationToken_identifier_token_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "work_upload": {
+      "name": "work_upload",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "work_upload_student_id_student_id_fk": {
+          "name": "work_upload_student_id_student_id_fk",
+          "tableFrom": "work_upload",
+          "tableTo": "student",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_upload_uploaded_by_id_user_id_fk": {
+          "name": "work_upload_uploaded_by_id_user_id_fk",
+          "tableFrom": "work_upload",
+          "tableTo": "user",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1751843641859,
       "tag": "0000_polite_kate_bishop",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1751849988238,
+      "tag": "0001_wet_penance",
+      "breakpoints": true
     }
   ]
 }

--- a/app/src/app/api/auth/[...nextauth]/route.ts
+++ b/app/src/app/api/auth/[...nextauth]/route.ts
@@ -1,23 +1,6 @@
 import NextAuth from 'next-auth';
-import EmailProvider from 'next-auth/providers/email';
-import { DrizzleAdapter } from '@auth/drizzle-adapter';
-import { db } from '@/db';
+import { authOptions } from '../options';
 
-const handler = NextAuth({
-  adapter: DrizzleAdapter(db),
-  providers: [
-    EmailProvider({
-      server: {
-        host: process.env.SMTP_HOST,
-        port: Number(process.env.SMTP_PORT),
-        auth: {
-          user: process.env.SMTP_USER,
-          pass: process.env.SMTP_PASS,
-        },
-      },
-      from: process.env.SMTP_FROM,
-    }),
-  ],
-});
+const handler = NextAuth(authOptions);
 
 export { handler as GET, handler as POST };

--- a/app/src/app/api/auth/options.ts
+++ b/app/src/app/api/auth/options.ts
@@ -1,0 +1,20 @@
+import EmailProvider from 'next-auth/providers/email';
+import { DrizzleAdapter } from '@auth/drizzle-adapter';
+import { db } from '@/db';
+
+export const authOptions = {
+  adapter: DrizzleAdapter(db),
+  providers: [
+    EmailProvider({
+      server: {
+        host: process.env.SMTP_HOST,
+        port: Number(process.env.SMTP_PORT),
+        auth: {
+          user: process.env.SMTP_USER,
+          pass: process.env.SMTP_PASS,
+        },
+      },
+      from: process.env.SMTP_FROM,
+    }),
+  ],
+};

--- a/app/src/app/api/upload-work/route.ts
+++ b/app/src/app/api/upload-work/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../auth/options';
+import { db } from '@/db';
+import { students, workUploads } from '@/db/schema';
+import { eq } from 'drizzle-orm';
+import { OpenAI } from 'openai';
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const userId = (session as any)?.user?.id as string | undefined;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const form = await req.formData();
+  const file = form.get('file');
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'File required' }, { status: 400 });
+  }
+  const summary = String(form.get('summary') || '');
+  const completed = form.get('completedDate')
+    ? new Date(String(form.get('completedDate')))
+    : null;
+  const studentName = String(form.get('studentName') || '');
+
+  // Find or create student
+  let studentId: string | undefined;
+  const existing = await db
+    .select()
+    .from(students)
+    .where(eq(students.name, studentName));
+  if (existing.length > 0) {
+    studentId = existing[0].id;
+  } else {
+    const inserted = await db
+      .insert(students)
+      .values({ name: studentName })
+      .returning({ id: students.id });
+    studentId = inserted[0].id;
+  }
+
+  const text = await file.text();
+  let embeddingJson: string | null = null;
+  try {
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || '' });
+    const embedding = await openai.embeddings.create({
+      model: 'multimodal-embedding-3-small',
+      input: text,
+    });
+    embeddingJson = JSON.stringify(embedding);
+  } catch (err) {
+    console.error('embedding failed', err);
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+
+  await db.insert(workUploads).values({
+    studentId,
+    uploadedById: userId,
+    uploadedAt: Date.now(),
+    completedAt: completed ? completed.getTime() : null,
+    summary,
+    embedding: embeddingJson,
+    file: buffer,
+  } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  return NextResponse.json({ success: true });
+}

--- a/app/src/app/upload-work/page.tsx
+++ b/app/src/app/upload-work/page.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useState } from 'react';
+
+export default function UploadWorkPage() {
+  const [status, setStatus] = useState('');
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Upload Work</h1>
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+          const form = e.target as HTMLFormElement;
+          const data = new FormData(form);
+          const res = await fetch('/api/upload-work', {
+            method: 'POST',
+            body: data,
+          });
+          if (res.ok) {
+            setStatus('Uploaded');
+            form.reset();
+          } else {
+            const j = await res.json();
+            setStatus(j.error || 'Error');
+          }
+        }}
+      >
+        <div>
+          <label>
+            Student Name
+            <input name="studentName" required />
+          </label>
+        </div>
+        <div>
+          <label>
+            Date Completed
+            <input type="date" name="completedDate" />
+          </label>
+        </div>
+        <div>
+          <label>
+            Summary
+            <textarea name="summary" required />
+          </label>
+        </div>
+        <div>
+          <label>
+            File
+            <input type="file" name="file" required />
+          </label>
+        </div>
+        <button type="submit">Upload</button>
+      </form>
+      {status && <p>{status}</p>}
+    </div>
+  );
+}

--- a/app/src/app/uploaded-work/page.tsx
+++ b/app/src/app/uploaded-work/page.tsx
@@ -1,0 +1,30 @@
+import { db } from '@/db';
+import { workUploads, students } from '@/db/schema';
+import { UploadedWorkList } from '@/components/UploadedWorkList';
+import { eq } from 'drizzle-orm';
+
+export default async function UploadedWorkPage() {
+  const rows = await db
+    .select({
+      id: workUploads.id,
+      summary: workUploads.summary,
+      completedAt: workUploads.completedAt,
+      studentName: students.name,
+    })
+    .from(workUploads)
+    .leftJoin(students, eq(workUploads.studentId, students.id));
+
+  const items = rows.map((r) => ({
+    id: r.id,
+    summary: r.summary ?? '',
+    studentName: r.studentName ?? 'Unknown',
+    completedAt: r.completedAt ? new Date(r.completedAt) : null,
+  }));
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Uploaded Work</h1>
+      <UploadedWorkList items={items} />
+    </div>
+  );
+}

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -35,6 +35,12 @@ export function NavBar() {
       <Link href="/" style={styles.link}>
         Home
       </Link>
+      <Link href="/upload-work" style={styles.link}>
+        Upload Work
+      </Link>
+      <Link href="/uploaded-work" style={styles.link}>
+        Uploaded Work
+      </Link>
       <div style={styles.spacer} />
       {session ? (
         <button style={styles.button} onClick={() => signOut()}>

--- a/app/src/components/UploadedWorkList.stories.tsx
+++ b/app/src/components/UploadedWorkList.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { UploadedWorkList } from './UploadedWorkList';
+
+const meta: Meta<typeof UploadedWorkList> = {
+  component: UploadedWorkList,
+  args: {
+    items: [
+      { id: '1', studentName: 'Alice', summary: 'Essay', completedAt: new Date() },
+    ],
+  },
+};
+export default meta;
+
+export const Default: StoryObj<typeof UploadedWorkList> = {};

--- a/app/src/components/UploadedWorkList.test.tsx
+++ b/app/src/components/UploadedWorkList.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { UploadedWorkList } from './UploadedWorkList';
+
+test('renders uploaded work', () => {
+  render(
+    <UploadedWorkList
+      items={[{ id: '1', studentName: 'Bob', summary: 'Math worksheet', completedAt: null }]}
+    />
+  );
+  expect(screen.getByText('Bob')).toBeInTheDocument();
+  expect(screen.getByText(/Math worksheet/)).toBeInTheDocument();
+});

--- a/app/src/components/UploadedWorkList.tsx
+++ b/app/src/components/UploadedWorkList.tsx
@@ -1,0 +1,21 @@
+export type UploadedWork = {
+  id: string;
+  studentName: string;
+  summary: string;
+  completedAt: Date | null;
+};
+
+export function UploadedWorkList({ items }: { items: UploadedWork[] }) {
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.id}>
+          <strong>{item.studentName}</strong> - {item.summary}
+          {item.completedAt && (
+            <span> (completed {item.completedAt.toDateString()})</span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, primaryKey } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, blob, primaryKey } from 'drizzle-orm/sqlite-core';
 
 export const users = sqliteTable('user', {
   id: text('id').primaryKey().notNull().$defaultFn(() => crypto.randomUUID()),
@@ -68,3 +68,25 @@ export const authenticators = sqliteTable(
     pk: primaryKey(authenticator.userId, authenticator.credentialID),
   })
 );
+
+export const students = sqliteTable('student', {
+  id: text('id').primaryKey().notNull().$defaultFn(() => crypto.randomUUID()),
+  name: text('name').notNull(),
+});
+
+export const workUploads = sqliteTable('work_upload', {
+  id: text('id').primaryKey().notNull().$defaultFn(() => crypto.randomUUID()),
+  studentId: text('student_id')
+    .notNull()
+    .references(() => students.id, { onDelete: 'cascade' }),
+  uploadedById: text('uploaded_by_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  uploadedAt: integer('uploaded_at', { mode: 'timestamp_ms' })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  completedAt: integer('completed_at', { mode: 'timestamp_ms' }),
+  summary: text('summary'),
+  embedding: text('embedding'),
+  file: blob('file'),
+});


### PR DESCRIPTION
## Summary
- allow uploading work and listing uploads
- store uploads and students in database schema
- add API route and upload pages
- link Upload Work and Uploaded Work in NavBar
- create UploadedWorkList component with story and test
- document uploaded work feature
- generate new Drizzle migration

## Testing
- `pnpm lint`
- `pnpm panda`
- `pnpm test`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_686b1a4df0fc832b923d5b76f72744af