### PR TITLE
Add uploaded work support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A web application for planning and tracking long term learning goals. Users defi
 
 Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**.
 
+An **Uploaded Work** page lets authenticated users store documents. Each upload records the completion date, a summary, embeddings, and the file itself for later review.
+
 The home page includes a math skill selector that generates a mermaid DAG of prerequisites using the built-in LLM client.
 
 ## Tech Stack

--- a/app/src/app/api/auth/[...nextauth]/route.ts
+++ b/app/src/app/api/auth/[...nextauth]/route.ts
@@ -1,23 +1,6 @@
 import NextAuth from 'next-auth';
-import EmailProvider from 'next-auth/providers/email';
-import { DrizzleAdapter } from '@auth/drizzle-adapter';
-import { db } from '@/db';
+import { authOptions } from '@/auth/options';
 
-const handler = NextAuth({
-  adapter: DrizzleAdapter(db),
-  providers: [
-    EmailProvider({
-      server: {
-        host: process.env.SMTP_HOST,
-        port: Number(process.env.SMTP_PORT),
-        auth: {
-          user: process.env.SMTP_USER,
-          pass: process.env.SMTP_PASS,
-        },
-      },
-      from: process.env.SMTP_FROM,
-    }),
-  ],
-});
+const handler = NextAuth(authOptions);
 
 export { handler as GET, handler as POST };

--- a/app/src/app/api/upload-work/route.ts
+++ b/app/src/app/api/upload-work/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/db';
+import { workUploads } from '@/db/schema';
+import { authOptions } from '@/auth/options';
+import { getServerSession } from 'next-auth';
+import OpenAI from 'openai';
+import fs from 'fs/promises';
+import path from 'path';
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const userId = (session?.user as { id?: string })?.id;
+  if (!session || !userId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const data = await req.formData();
+  const file = data.get('file');
+  const summary = data.get('summary') as string | null;
+  const completedAt = data.get('completedAt') as string | null;
+  const student = (data.get('student') as string | null) || '';
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'file required' }, { status: 400 });
+  }
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const id = crypto.randomUUID();
+  const uploadDir = path.join(process.cwd(), 'public', 'uploads');
+  await fs.mkdir(uploadDir, { recursive: true });
+  const ext = path.extname(file.name);
+  const filename = `${id}${ext}`;
+  await fs.writeFile(path.join(uploadDir, filename), buffer);
+
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || '' });
+  const embeddingRes = await openai.embeddings.create({
+    model: 'multimodal-embedding-3-small',
+    input: summary || '',
+  });
+  const embedding = JSON.stringify(embeddingRes.data[0]?.embedding || []);
+
+  await db.insert(workUploads).values({
+    id,
+    userId,
+    student,
+    uploadedAt: new Date(),
+    completedAt: completedAt ? new Date(completedAt) : null,
+    summary: summary || '',
+    embedding,
+    file: filename,
+    originalName: file.name,
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/app/src/app/work/page.tsx
+++ b/app/src/app/work/page.tsx
@@ -1,0 +1,32 @@
+import { db } from '@/db';
+import { workUploads } from '@/db/schema';
+import { authOptions } from '@/auth/options';
+import { getServerSession } from 'next-auth';
+import { UploadWorkForm } from '@/components/UploadWorkForm';
+import { eq } from 'drizzle-orm';
+import Link from 'next/link';
+
+export default async function WorkPage() {
+  const session = await getServerSession(authOptions);
+  const userId = (session?.user as { id?: string })?.id;
+  if (!session || !userId) {
+    return <p>Please sign in to view uploads.</p>;
+  }
+  const uploads = await db
+    .select()
+    .from(workUploads)
+    .where(eq(workUploads.userId, userId));
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Uploaded Work</h1>
+      <UploadWorkForm />
+      <ul>
+        {uploads.map((u) => (
+          <li key={u.id}>
+            <Link href={`/uploads/${u.file}`}>{u.originalName}</Link> - {u.summary}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/src/auth/options.ts
+++ b/app/src/auth/options.ts
@@ -1,0 +1,21 @@
+import EmailProvider from 'next-auth/providers/email';
+import { DrizzleAdapter } from '@auth/drizzle-adapter';
+import type { NextAuthOptions } from 'next-auth';
+import { db } from '@/db';
+
+export const authOptions: NextAuthOptions = {
+  adapter: DrizzleAdapter(db),
+  providers: [
+    EmailProvider({
+      server: {
+        host: process.env.SMTP_HOST,
+        port: Number(process.env.SMTP_PORT),
+        auth: {
+          user: process.env.SMTP_USER,
+          pass: process.env.SMTP_PASS,
+        },
+      },
+      from: process.env.SMTP_FROM,
+    }),
+  ],
+};

--- a/app/src/components/NavBar.test.tsx
+++ b/app/src/components/NavBar.test.tsx
@@ -23,3 +23,9 @@ test('shows sign out when authenticated', () => {
   render(<NavBar />);
   expect(screen.getByText('Sign out')).toBeInTheDocument();
 });
+
+test('shows work link when authenticated', () => {
+  mockedUseSession.mockReturnValue({ data: { user: { name: 'a' }, expires: '1' }, status: 'authenticated' });
+  render(<NavBar />);
+  expect(screen.getByText('Uploaded Work')).toBeInTheDocument();
+});

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -35,6 +35,11 @@ export function NavBar() {
       <Link href="/" style={styles.link}>
         Home
       </Link>
+      {session && (
+        <Link href="/work" style={styles.link}>
+          Uploaded Work
+        </Link>
+      )}
       <div style={styles.spacer} />
       {session ? (
         <button style={styles.button} onClick={() => signOut()}>

--- a/app/src/components/UploadWorkForm.stories.tsx
+++ b/app/src/components/UploadWorkForm.stories.tsx
@@ -1,0 +1,11 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { UploadWorkForm } from './UploadWorkForm';
+
+const meta: Meta<typeof UploadWorkForm> = {
+  component: UploadWorkForm,
+};
+export default meta;
+
+export const Basic: StoryObj<typeof UploadWorkForm> = {
+  render: () => <UploadWorkForm />,
+};

--- a/app/src/components/UploadWorkForm.test.tsx
+++ b/app/src/components/UploadWorkForm.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import { UploadWorkForm } from './UploadWorkForm';
+
+test('renders upload button', () => {
+  render(<UploadWorkForm />);
+  expect(screen.getByText('Upload')).toBeInTheDocument();
+});

--- a/app/src/components/UploadWorkForm.tsx
+++ b/app/src/components/UploadWorkForm.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useRef, useState, FormEvent } from 'react';
+
+export type UploadWorkFormProps = {
+  onUploaded?: () => void;
+};
+
+export function UploadWorkForm({ onUploaded }: UploadWorkFormProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const [error, setError] = useState('');
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    const form = formRef.current;
+    if (!form) return;
+    const data = new FormData(form);
+    const res = await fetch('/api/upload-work', { method: 'POST', body: data });
+    if (res.ok) {
+      setError('');
+      form.reset();
+      onUploaded?.();
+    } else {
+      const json = await res.json().catch(() => null);
+      setError(json?.error || 'Upload failed');
+    }
+  };
+  return (
+    <form ref={formRef} onSubmit={submit}>
+      <div>
+        <input name="file" type="file" required />
+      </div>
+      <div>
+        <label>
+          Completed At
+          <input name="completedAt" type="date" required />
+        </label>
+      </div>
+      <div>
+        <label>
+          Student
+          <input name="student" type="text" />
+        </label>
+      </div>
+      <div>
+        <label>
+          Summary
+          <textarea name="summary" required />
+        </label>
+      </div>
+      <button type="submit">Upload</button>
+      {error && <p>{error}</p>}
+    </form>
+  );
+}

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -68,3 +68,19 @@ export const authenticators = sqliteTable(
     pk: primaryKey(authenticator.userId, authenticator.credentialID),
   })
 );
+
+export const workUploads = sqliteTable('work_upload', {
+  id: text('id').primaryKey().notNull().$defaultFn(() => crypto.randomUUID()),
+  userId: text('user_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  student: text('student'),
+  uploadedAt: integer('uploaded_at', { mode: 'timestamp_ms' })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  completedAt: integer('completed_at', { mode: 'timestamp_ms' }),
+  summary: text('summary'),
+  embedding: text('embedding'),
+  file: text('file'),
+  originalName: text('original_name'),
+});


### PR DESCRIPTION
## Summary
- enable uploading work documents
- show uploaded documents for signed-in users
- display a link to Uploaded Work in the nav bar
- document the Uploaded Work feature

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm exec prisma migrate dev` *(fails: Command "prisma" not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1a4df0fc832b923d5b76f72744af