### PR TITLE
Improve LLM graph validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A web application for planning and tracking long term learning goals. Users defi
 
 Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**.
 
-The home page includes a math skill selector that generates a mermaid DAG of prerequisites using the built-in LLM client.
+The home page includes a math skill selector that generates a mermaid DAG of prerequisites using the built-in LLM client. Generated diagrams are validated server-side and any LLM-provided error explanations are surfaced to the user.
 
 ## Tech Stack
 

--- a/app/package.json
+++ b/app/package.json
@@ -22,6 +22,7 @@
     "casbin": "^5.38.0",
     "drizzle-kit": "^0.31.4",
     "drizzle-orm": "^0.44.2",
+    "mermaid": "8.14.0",
     "next": "15.3.5",
     "next-auth": "^4.24.11",
     "nodemailer": "^7.0.4",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -23,12 +23,15 @@ importers:
       drizzle-orm:
         specifier: ^0.44.2
         version: 0.44.2(@prisma/client@6.11.1(prisma@6.11.1(typescript@5.8.3))(typescript@5.8.3))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.2.0)(prisma@6.11.1(typescript@5.8.3))(sqlite3@5.1.7)
+      mermaid:
+        specifier: 8.14.0
+        version: 8.14.0
       next:
         specifier: 15.3.5
-        version: 15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.5(@babel/core@7.7.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.11(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 4.24.11(next@15.3.5(@babel/core@7.7.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       nodemailer:
         specifier: ^7.0.4
         version: 7.0.4
@@ -77,7 +80,7 @@ importers:
         version: 9.0.15(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5))(vitest@3.2.4)
       '@storybook/nextjs-vite':
         specifier: ^9.0.15
-        version: 9.0.15(@babel/core@7.28.0)(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.44.2)(storybook@9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5))(typescript@5.8.3)(vite@7.0.2(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.43.1))
+        version: 9.0.15(@babel/core@7.7.4)(next@15.3.5(@babel/core@7.7.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.44.2)(storybook@9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5))(typescript@5.8.3)(vite@7.0.2(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.43.1))
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
@@ -11794,18 +11797,18 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@storybook/nextjs-vite@9.0.15(@babel/core@7.28.0)(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.44.2)(storybook@9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5))(typescript@5.8.3)(vite@7.0.2(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.43.1))':
+  '@storybook/nextjs-vite@9.0.15(@babel/core@7.7.4)(next@15.3.5(@babel/core@7.7.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.44.2)(storybook@9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5))(typescript@5.8.3)(vite@7.0.2(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.43.1))':
     dependencies:
       '@storybook/builder-vite': 9.0.15(storybook@9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5))(vite@7.0.2(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.43.1))
       '@storybook/react': 9.0.15(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5))(typescript@5.8.3)
       '@storybook/react-vite': 9.0.15(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.44.2)(storybook@9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5))(typescript@5.8.3)(vite@7.0.2(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.43.1))
-      next: 15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.5(@babel/core@7.7.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       storybook: 9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5)
-      styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.1.0)
+      styled-jsx: 5.1.6(@babel/core@7.7.4)(react@19.1.0)
       vite: 7.0.2(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.43.1)
-      vite-plugin-storybook-nextjs: 2.0.5(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(storybook@9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5))(typescript@5.8.3)(vite@7.0.2(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.43.1))
+      vite-plugin-storybook-nextjs: 2.0.5(next@15.3.5(@babel/core@7.7.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(storybook@9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5))(typescript@5.8.3)(vite@7.0.2(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.43.1))
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -12121,10 +12124,10 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@2.34.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@2.34.0(@typescript-eslint/parser@2.34.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/experimental-utils': 2.34.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/parser': 2.34.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.30.1(jiti@2.4.2)
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
@@ -14836,7 +14839,7 @@ snapshots:
 
   eslint-config-react-app@5.2.1(@typescript-eslint/eslint-plugin@2.34.0(@typescript-eslint/parser@2.34.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(@typescript-eslint/parser@2.34.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(babel-eslint@10.0.3(eslint@9.30.1(jiti@2.4.2)))(eslint-plugin-flowtype@3.13.0(eslint@9.30.1(jiti@2.4.2)))(eslint-plugin-import@2.18.2(@typescript-eslint/parser@2.34.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2)))(eslint-plugin-jsx-a11y@6.2.3(eslint@9.30.1(jiti@2.4.2)))(eslint-plugin-react-hooks@1.7.0(eslint@9.30.1(jiti@2.4.2)))(eslint-plugin-react@7.16.0(eslint@9.30.1(jiti@2.4.2)))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@2.34.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/parser': 2.34.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       babel-eslint: 10.0.3(eslint@9.30.1(jiti@2.4.2))
       confusing-browser-globals: 1.0.11
@@ -17458,13 +17461,13 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-auth@4.24.11(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next-auth@4.24.11(next@15.3.5(@babel/core@7.7.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/runtime': 7.27.6
       '@panva/hkdf': 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.5(@babel/core@7.7.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.26.9
@@ -17477,7 +17480,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.3.5(@babel/core@7.7.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.3.5
       '@swc/counter': 0.1.3
@@ -17487,7 +17490,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.1.0)
+      styled-jsx: 5.1.6(@babel/core@7.7.4)(react@19.1.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.3.5
       '@next/swc-darwin-x64': 15.3.5
@@ -18862,7 +18865,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.7.4
       '@svgr/webpack': 4.3.3
-      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 2.34.0(@typescript-eslint/parser@2.34.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/parser': 2.34.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       babel-eslint: 10.0.3(eslint@9.30.1(jiti@2.4.2))
       babel-jest: 24.9.0(@babel/core@7.7.4)
@@ -19964,12 +19967,12 @@ snapshots:
       schema-utils: 2.7.1
       webpack: 4.41.2
 
-  styled-jsx@5.1.6(@babel/core@7.28.0)(react@19.1.0):
+  styled-jsx@5.1.6(@babel/core@7.7.4)(react@19.1.0):
     dependencies:
       client-only: 0.0.1
       react: 19.1.0
     optionalDependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.7.4
 
   stylehacks@4.0.3:
     dependencies:
@@ -20539,13 +20542,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-storybook-nextjs@2.0.5(next@15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(storybook@9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5))(typescript@5.8.3)(vite@7.0.2(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.43.1)):
+  vite-plugin-storybook-nextjs@2.0.5(next@15.3.5(@babel/core@7.7.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(storybook@9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5))(typescript@5.8.3)(vite@7.0.2(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.43.1)):
     dependencies:
       '@next/env': 15.3.5
       image-size: 2.0.2
       magic-string: 0.30.17
       module-alias: 2.2.3
-      next: 15.3.5(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.5(@babel/core@7.7.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       storybook: 9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5)
       ts-dedent: 2.2.0
       vite: 7.0.2(@types/node@20.19.4)(jiti@2.4.2)(lightningcss@1.25.1)(terser@5.43.1)

--- a/app/src/app/api/generate-graph/route.ts
+++ b/app/src/app/api/generate-graph/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+import mermaid from 'mermaid';
 import { LLMClient } from '@/llm/client';
 
 const bodySchema = z.object({ topics: z.array(z.string()) });
@@ -14,15 +15,37 @@ export async function POST(req: NextRequest) {
     console.log('OPENAI_API_KEY loaded');
   }
   const client = new LLMClient(apiKey || '');
-  const schema = z.object({ graph: z.string() });
+  const schema = z.object({
+    graph: z.string().optional(),
+    errorReason: z.string().optional(),
+  });
   const prompt = `Create a mermaid DAG showing a progression from kindergarten math to these topics: ${topics.join(', ')}. Include prerequisite links.`;
   const result = await client.chat(prompt, {
-    systemPrompt: 'You are an expert math curriculum planner.',
+    systemPrompt:
+      'You are an expert math curriculum planner. Return a JSON object with a "graph" field containing mermaid code or an "errorReason" explaining why a graph cannot be produced.',
     schema,
   });
   if (result.error || !result.response) {
     console.error('LLM chat failed', result.error);
     return NextResponse.json({ error: result.error?.message || 'error' }, { status: 500 });
   }
-  return NextResponse.json({ graph: result.response.graph });
+  const { graph, errorReason } = result.response;
+  if (errorReason) {
+    console.error('LLM returned error reason', errorReason);
+    return NextResponse.json({ error: errorReason }, { status: 400 });
+  }
+  if (!graph) {
+    return NextResponse.json({ error: 'No graph returned' }, { status: 500 });
+  }
+  try {
+    mermaid.parse(graph);
+  } catch (err: unknown) {
+    const message =
+      typeof err === 'object' && err && 'str' in err
+        ? String((err as { str?: unknown }).str)
+        : String(err);
+    console.error('Invalid mermaid code', message);
+    return NextResponse.json({ error: `Invalid mermaid diagram: ${message}` }, { status: 400 });
+  }
+  return NextResponse.json({ graph });
 }

--- a/app/src/components/MathSkillSelector.test.tsx
+++ b/app/src/components/MathSkillSelector.test.tsx
@@ -2,11 +2,20 @@ import { render, screen, fireEvent } from '@testing-library/react';
 vi.mock('react-mermaid2', () => ({ default: () => <div data-testid="mermaid" /> }));
 import { MathSkillSelector } from './MathSkillSelector';
 
-vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ graph: 'g' }) }));
+const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ graph: 'g' }) });
+vi.stubGlobal('fetch', mockFetch);
 
 test('calls API with selected topics', async () => {
   render(<MathSkillSelector />);
   fireEvent.click(screen.getByLabelText('Algebra'));
   fireEvent.click(screen.getByText('Generate Graph'));
   expect(fetch).toHaveBeenCalledWith('/api/generate-graph', expect.objectContaining({ method: 'POST' }));
+});
+
+test('shows error message when API returns error', async () => {
+  mockFetch.mockResolvedValueOnce({ ok: false, json: () => Promise.resolve({ error: 'bad' }) });
+  render(<MathSkillSelector />);
+  fireEvent.click(screen.getByText('Generate Graph'));
+  const alert = await screen.findByRole('alert');
+  expect(alert).toHaveTextContent('bad');
 });

--- a/app/src/components/MathSkillSelector.tsx
+++ b/app/src/components/MathSkillSelector.tsx
@@ -28,6 +28,7 @@ const skills = [
 export function MathSkillSelector() {
   const [selected, setSelected] = useState<string[]>([]);
   const [graph, setGraph] = useState('');
+  const [error, setError] = useState('');
 
   const toggle = (skill: string) => {
     setSelected((prev) =>
@@ -41,8 +42,12 @@ export function MathSkillSelector() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ topics: selected }),
     });
-    if (res.ok) {
-      const data = (await res.json()) as { graph: string };
+    const data = (await res.json()) as { graph?: string; error?: string };
+    if (!res.ok || data.error) {
+      setError(data.error || 'Failed to generate graph');
+      setGraph('');
+    } else if (data.graph) {
+      setError('');
       setGraph(data.graph);
     }
   };
@@ -64,8 +69,9 @@ export function MathSkillSelector() {
       <button style={styles.button} onClick={generate}>
         Generate Graph
       </button>
-        {graph && (
-          <div id="graph-container" style={styles.graph}>
+      {error && <p role="alert">{error}</p>}
+      {graph && (
+        <div id="graph-container" style={styles.graph}>
             {/* re-mount Mermaid when chart string changes to ensure re-render */}
             <Mermaid key={graph} chart={graph} />
           </div>

--- a/app/src/mermaid.d.ts
+++ b/app/src/mermaid.d.ts
@@ -1,0 +1,1 @@
+declare module 'mermaid';

--- a/app/src/styled-system.d.ts
+++ b/app/src/styled-system.d.ts
@@ -1,0 +1,3 @@
+declare module '@/styled-system/css' {
+  export function css(args: unknown): string;
+}

--- a/app/vitest.setup.ts
+++ b/app/vitest.setup.ts
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom';
+vi.mock('@/styled-system/css', () => ({ css: () => '' }));


### PR DESCRIPTION
## Summary
- show LLM error responses in UI
- validate mermaid diagrams server-side
- add typing stubs for mermaid and styled-system
- test error path for MathSkillSelector
- document server-side mermaid validation

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: Next.js build didn't finish in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_686b272bfc98832bb33f26b4a41be1b5