### PR TITLE
Validate mermaid diagrams and handle LLM errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A web application for planning and tracking long term learning goals. Users defi
 
 Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**.
 
-The home page includes a math skill selector that generates a mermaid DAG of prerequisites using the built-in LLM client.
+The home page includes a math skill selector that generates a mermaid DAG of prerequisites using the built-in LLM client. Mermaid output from the model is validated server‑side before display and the API may return an error message when generation fails.
 
 ## Tech Stack
 

--- a/app/src/app/api/generate-graph/route.ts
+++ b/app/src/app/api/generate-graph/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+import mermaid from 'mermaid';
 import { LLMClient } from '@/llm/client';
 
 const bodySchema = z.object({ topics: z.array(z.string()) });
@@ -14,7 +15,10 @@ export async function POST(req: NextRequest) {
     console.log('OPENAI_API_KEY loaded');
   }
   const client = new LLMClient(apiKey || '');
-  const schema = z.object({ graph: z.string() });
+  const schema = z.object({
+    graph: z.string().optional(),
+    errorReason: z.string().optional(),
+  });
   const prompt = `Create a mermaid DAG showing a progression from kindergarten math to these topics: ${topics.join(', ')}. Include prerequisite links.`;
   const result = await client.chat(prompt, {
     systemPrompt: 'You are an expert math curriculum planner.',
@@ -24,5 +28,16 @@ export async function POST(req: NextRequest) {
     console.error('LLM chat failed', result.error);
     return NextResponse.json({ error: result.error?.message || 'error' }, { status: 500 });
   }
-  return NextResponse.json({ graph: result.response.graph });
+  if (result.response.errorReason) {
+    console.error('LLM returned error reason', result.response.errorReason);
+    return NextResponse.json({ error: result.response.errorReason }, { status: 400 });
+  }
+  const graph = result.response.graph || '';
+  try {
+    mermaid.parse(graph);
+  } catch (e) {
+    console.error('Mermaid validation failed', e);
+    return NextResponse.json({ error: 'Invalid mermaid graph generated' }, { status: 500 });
+  }
+  return NextResponse.json({ graph });
 }

--- a/app/src/components/MathSkillSelector.test.tsx
+++ b/app/src/components/MathSkillSelector.test.tsx
@@ -2,11 +2,30 @@ import { render, screen, fireEvent } from '@testing-library/react';
 vi.mock('react-mermaid2', () => ({ default: () => <div data-testid="mermaid" /> }));
 import { MathSkillSelector } from './MathSkillSelector';
 
-vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ graph: 'g' }) }));
+vi.stubGlobal(
+  'fetch',
+  vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ graph: 'g' }) })
+);
 
 test('calls API with selected topics', async () => {
   render(<MathSkillSelector />);
   fireEvent.click(screen.getByLabelText('Algebra'));
   fireEvent.click(screen.getByText('Generate Graph'));
   expect(fetch).toHaveBeenCalledWith('/api/generate-graph', expect.objectContaining({ method: 'POST' }));
+});
+
+test('displays graph on success', async () => {
+  render(<MathSkillSelector />);
+  fireEvent.click(screen.getByText('Generate Graph'));
+  expect(await screen.findByTestId('mermaid')).toBeInTheDocument();
+});
+
+test('shows error when api responds with error', async () => {
+  (fetch as unknown as vi.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ error: 'no graph' }),
+  });
+  render(<MathSkillSelector />);
+  fireEvent.click(screen.getByText('Generate Graph'));
+  expect(await screen.findByRole('alert')).toHaveTextContent('no graph');
 });

--- a/app/src/llm/README.md
+++ b/app/src/llm/README.md
@@ -12,6 +12,7 @@ const client = new LLMClient(process.env.OPENAI_API_KEY!);
 
 const schema = z.object({
   message: z.string(),
+  errorReason: z.string().optional(),
 });
 
 const result = await client.chat('Say hello to {{name}}', {
@@ -26,6 +27,9 @@ if (result.error) {
   console.log(result.response);
 }
 ```
+
+The schema can include optional fields like `errorReason` so the model can
+provide an explanation when it declines to answer.
 
 The client will try up to `maxRetries` times (default `3`) when the model returns output that cannot be parsed with the provided schema. On each retry it explains the validation error to the model via a system message.
 

--- a/app/src/mermaid.d.ts
+++ b/app/src/mermaid.d.ts
@@ -1,0 +1,1 @@
+declare module 'mermaid';


### PR DESCRIPTION
## Summary
- allow `generate-graph` API to receive an errorReason from the LLM
- validate mermaid diagrams server-side before returning them
- surface generation errors to users in `MathSkillSelector`
- document optional `errorReason` field for the LLM client
- note mermaid validation in the README

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Could not resolve imports and act warnings)*
- `pnpm build` *(fails: better-sqlite3 bindings not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b272bfc98832bb33f26b4a41be1b5