### PR TITLE
Add e2e test harness using Vitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ pnpm dev
 pnpm test
 ```
 
+Run end-to-end tests:
+
+```bash
+pnpm test:e2e
+```
+
 ### Storybook
 
 ```bash

--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "postinstall": "npm rebuild better-sqlite3",
     "storybook": "storybook dev -p 6006 --ci",
     "build-storybook": "storybook build",

--- a/app/tests/e2e/generateGraph.test.ts
+++ b/app/tests/e2e/generateGraph.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST as generateGraph } from '@/app/api/generate-graph/route';
+
+vi.mock('@/llm/client', () => {
+  return {
+    LLMClient: vi.fn().mockImplementation(() => ({
+      chat: vi.fn(async () => ({ error: null, response: { graph: 'test-graph' } }))
+    }))
+  };
+});
+
+describe('generate-graph API', () => {
+  it('returns graph json', async () => {
+    const req = new NextRequest(new Request('http://localhost/api/generate-graph', {
+      method: 'POST',
+      body: JSON.stringify({ topics: ['algebra'] }),
+      headers: { 'content-type': 'application/json' }
+    }));
+    const res = await generateGraph(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.graph).toBe('test-graph');
+  });
+});

--- a/app/tests/e2e/uploadWork.test.ts
+++ b/app/tests/e2e/uploadWork.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST as uploadWork } from '@/app/api/upload-work/route';
+import { getServerSession } from 'next-auth';
+
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }));
+vi.mock('openai', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    chat: { completions: { create: vi.fn().mockResolvedValue({ choices: [{ message: { content: 'sum' } }] }) } },
+    embeddings: { create: vi.fn().mockResolvedValue({ data: [] }) }
+  }))
+}));
+
+describe('upload-work API', () => {
+  it('rejects unauthenticated users', async () => {
+    (getServerSession as unknown as vi.Mock).mockResolvedValue(null);
+    const form = new FormData();
+    form.set('file', new File(['hello'], 'hello.txt'));
+    form.set('studentId', '1');
+    const req = new NextRequest(new Request('http://localhost/api/upload-work', { method: 'POST', body: form }));
+    const res = await uploadWork(req);
+    expect(res.status).toBe(401);
+  });
+});

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -9,8 +9,10 @@ export default defineConfig({
     }
   },
   test: {
+    include: ['src/**/*.test.{ts,tsx}'],
     environment: 'jsdom',
     globals: true,
     setupFiles: './vitest.setup.ts',
+    exclude: ['tests/e2e/**'],
   },
 });

--- a/app/vitest.e2e.config.ts
+++ b/app/vitest.e2e.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+      '@/': `${resolve(__dirname, 'src')}/`,
+      '@/styled-system': '/styled-system',
+    },
+  },
+  test: {
+    include: ['tests/e2e/**/*.test.ts'],
+    environment: 'node',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add `test:e2e` npm script
- configure vitest to ignore e2e tests in unit runs
- add new `vitest.e2e.config.ts` for node environment tests
- write API end-to-end tests
- update README documentation

## Testing
- `pnpm panda`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686b3d7f8e18832b8859cfa21d851302