### PR TITLE
Add link to Uploaded Work page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A web application for planning and tracking long term learning goals. Users define topic graphs and upload work samples. The app stores metadata and embeddings to recommend what to study next.
 
-Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**.
+Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**. The navigation bar also links to the **Uploaded Work** page.
 
 The home page includes a math skill selector that generates a mermaid DAG of prerequisites using the built-in LLM client.
 

--- a/app/src/components/NavBar.test.tsx
+++ b/app/src/components/NavBar.test.tsx
@@ -23,3 +23,9 @@ test('shows sign out when authenticated', () => {
   render(<NavBar />);
   expect(screen.getByText('Sign out')).toBeInTheDocument();
 });
+
+test('shows uploaded work link', () => {
+  mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+  render(<NavBar />);
+  expect(screen.getByText('Uploaded Work')).toBeInTheDocument();
+});

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -35,6 +35,9 @@ export function NavBar() {
       <Link href="/" style={styles.link}>
         Home
       </Link>
+      <Link href="/uploaded-work" style={styles.link}>
+        Uploaded Work
+      </Link>
       <div style={styles.spacer} />
       {session ? (
         <button style={styles.button} onClick={() => signOut()}>


### PR DESCRIPTION
## Summary
- add a nav bar link to `/uploaded-work`
- cover new link with tests
- document the new navigation option

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686bcf328100832b8010b457a779c19a