### PR TITLE
Add live update for uploaded work

### DIFF
--- a/app/src/app/uploaded-work/page.tsx
+++ b/app/src/app/uploaded-work/page.tsx
@@ -1,6 +1,6 @@
 import { db } from '@/db';
 import { uploadedWork } from '@/db/schema';
-import { UploadForm } from '@/components/UploadForm';
+import { UploadedWorkList } from '@/components/UploadedWorkList';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/authOptions';
 import { eq } from 'drizzle-orm';
@@ -20,18 +20,5 @@ export default async function UploadedWorkPage() {
     .select()
     .from(uploadedWork)
     .where(eq(uploadedWork.userId, userId));
-  return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Uploaded Work</h1>
-      <UploadForm />
-      <ul>
-        {works.map((w) => (
-          <li key={w.id} style={{ marginBottom: '1rem' }}>
-            <strong>{new Date(w.dateCompleted || w.dateUploaded).toDateString()}</strong>
-            <p>{w.summary}</p>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+  return <UploadedWorkList initialWorks={works} />;
 }

--- a/app/src/components/UploadedWorkList.stories.tsx
+++ b/app/src/components/UploadedWorkList.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta } from '@storybook/react'
+import { UploadedWorkList } from './UploadedWorkList'
+
+const meta: Meta<typeof UploadedWorkList> = {
+  title: 'UploadedWorkList',
+  component: UploadedWorkList,
+  args: {
+    initialWorks: [
+      { id: '1', dateUploaded: new Date(), dateCompleted: null, summary: 'Summary' }
+    ],
+  },
+}
+export default meta
+
+export const Default = {}

--- a/app/src/components/UploadedWorkList.test.tsx
+++ b/app/src/components/UploadedWorkList.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react'
+import { UploadedWorkList } from './UploadedWorkList'
+
+test('renders initial works', () => {
+  render(<UploadedWorkList initialWorks={[{ id: '1', dateUploaded: new Date(), dateCompleted: null, summary: 'Hi' }]} />)
+  expect(screen.getByText('Hi')).toBeInTheDocument()
+})

--- a/app/src/components/UploadedWorkList.tsx
+++ b/app/src/components/UploadedWorkList.tsx
@@ -1,0 +1,64 @@
+'use client'
+import { useState } from 'react'
+import { UploadForm, UploadFormCallbacks } from './UploadForm'
+export type UploadedWork = {
+  id: string
+  dateUploaded: Date
+  dateCompleted: Date | null
+  summary: string | null
+}
+
+export function UploadedWorkList({ initialWorks }: { initialWorks: UploadedWork[] }) {
+  const [works, setWorks] = useState<(UploadedWork & { processing?: boolean; error?: string })[]>(initialWorks)
+
+  const handleUploadStart: UploadFormCallbacks['onUploadStart'] = (id, { dateCompleted }) => {
+    setWorks((w) => [
+      {
+        id,
+        dateUploaded: new Date(),
+        dateCompleted: dateCompleted || null,
+        summary: '',
+        processing: true,
+      },
+      ...w,
+    ])
+  }
+
+  const handleUploadComplete: UploadFormCallbacks['onUploadComplete'] = async (id) => {
+    try {
+      const res = await fetch('/api/upload-work')
+      if (res.ok) {
+        const data = (await res.json()) as { works: UploadedWork[] }
+        setWorks(data.works)
+        return
+      }
+      throw new Error('Failed to refresh')
+    } catch {
+      setWorks((w) => w.map((item) => (item.id === id ? { ...item, processing: false, error: 'Upload failed' } : item)))
+    }
+  }
+
+  const handleUploadError: UploadFormCallbacks['onUploadError'] = (id, error) => {
+    setWorks((w) => w.map((item) => (item.id === id ? { ...item, processing: false, error: error.message } : item)))
+  }
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Uploaded Work</h1>
+      <UploadForm
+        onUploadStart={handleUploadStart}
+        onUploadComplete={handleUploadComplete}
+        onUploadError={handleUploadError}
+      />
+      <ul>
+        {works.map((w) => (
+          <li key={w.id} style={{ marginBottom: '1rem' }}>
+            <strong>{new Date(w.dateCompleted || w.dateUploaded).toDateString()}</strong>
+            {w.processing ? <p>Processing...</p> : <p>{w.summary}</p>}
+            {w.error && <p style={{ color: 'red' }}>{w.error}</p>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show uploaded work immediately after posting
- display placeholder while processing
- capture errors from upload
- add UploadedWorkList component with story and test

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686bf6161688832ba6dc0461d6c8d0db