### PR TITLE
Fix styled-system alias for tests

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,13 +1,14 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@/styled-system': '/styled-system',
-      '@': '/src',
-      '@/': '/src/'
+      '@/styled-system': resolve(__dirname, 'styled-system'),
+      '@': resolve(__dirname, 'src'),
+      '@/': `${resolve(__dirname, 'src')}/`
     }
   },
   test: {

--- a/app/vitest.e2e.config.ts
+++ b/app/vitest.e2e.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     alias: {
       '@': resolve(__dirname, 'src'),
       '@/': `${resolve(__dirname, 'src')}/`,
-      '@/styled-system': '/styled-system',
+      '@/styled-system': resolve(__dirname, 'styled-system'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- fix `styled-system` alias in vite config files

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686c0a33ac44832bb1c0724671052657