### PR TITLE
Load sqlite-vss when opening database

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The home page includes a math skill selector that generates a mermaid DAG of pre
 - **Mermaid diagrams** rendered with `react-mermaid2`
 - **TypeScript** throughout
 - **SQLite** database accessed via Drizzle ORM with migrations
+- **sqlite-vss** extension automatically loaded for vector search
 - **Vitest** for unit and e2e testing
 - **Storybook** for component development
 - **NextAuth** for authentication
@@ -46,6 +47,9 @@ pnpm exec drizzle-kit push
 Running this command will create any tables defined in the schema, including the
 `uploaded_work` table. When the `drizzle` folder exists, migrations run
 automatically at runtime.
+
+The `sqlite-vss` extension is installed via npm and loaded automatically when
+the database initializes, so no extra setup is required.
 
 
 ```bash

--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.10.0",
+    "@hookform/resolvers": "^3.3.1",
     "better-sqlite3": "^12.2.0",
     "casbin": "^5.38.0",
     "drizzle-kit": "^0.31.4",
@@ -29,13 +30,13 @@
     "openai": "^5.8.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.50.0",
     "react-katex": "^3.1.0",
     "react-mermaid2": "^0.1.4",
+    "sqlite-vss": "^0.1.2",
     "sqlite3": "^5.1.7",
     "zod": "^3.25.74",
-    "zod-to-json-schema": "^3.24.6",
-    "react-hook-form": "^7.50.0",
-    "@hookform/resolvers": "^3.3.1"
+    "zod-to-json-schema": "^3.24.6"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.0.1",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       react-mermaid2:
         specifier: ^0.1.4
         version: 0.1.4(@testing-library/dom@10.4.0)(@types/react@19.1.8)(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
+      sqlite-vss:
+        specifier: ^0.1.2
+        version: 0.1.2
       sqlite3:
         specifier: ^5.1.7
         version: 5.1.7
@@ -8328,6 +8331,24 @@ packages:
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  sqlite-vss-darwin-arm64@0.1.2:
+    resolution: {integrity: sha512-zyDk9eg33nBABrUC4cqQ7el8KJaRPzsqp8Y/nGZ0CAt7o1PMqLoCOgREorill5MGiZEBmLqxdAgw0O2MFwq4mw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  sqlite-vss-darwin-x64@0.1.2:
+    resolution: {integrity: sha512-w+ODOH2dNkyO6UaGclwC0jwNf/FBsKaE53XKJ7dFmpOvlvO0/9sA1stkWXygykRVWwa3UD8ow0qbQpRwdOFyqg==}
+    cpu: [x64]
+    os: [darwin]
+
+  sqlite-vss-linux-x64@0.1.2:
+    resolution: {integrity: sha512-y1qktcHAZcfN1nYMcF5os/cCRRyaisaNc2C9I3ceLKLPAqUWIocsOdD5nNK/dIeGPag/QeT2ZItJ6uYWciLiAg==}
+    cpu: [x64]
+    os: [linux]
+
+  sqlite-vss@0.1.2:
+    resolution: {integrity: sha512-MgTz3GLT04ckv1kaesbrsUU6/kcVsA6vGeCS/HO5d/8zKqCuZFCD0QlJaQnS6zwaMyPG++BO/uu40MMrMa0cow==}
 
   sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
@@ -19762,6 +19783,21 @@ snapshots:
 
   sprintf-js@1.1.3:
     optional: true
+
+  sqlite-vss-darwin-arm64@0.1.2:
+    optional: true
+
+  sqlite-vss-darwin-x64@0.1.2:
+    optional: true
+
+  sqlite-vss-linux-x64@0.1.2:
+    optional: true
+
+  sqlite-vss@0.1.2:
+    optionalDependencies:
+      sqlite-vss-darwin-arm64: 0.1.2
+      sqlite-vss-darwin-x64: 0.1.2
+      sqlite-vss-linux-x64: 0.1.2
 
   sqlite3@5.1.7:
     dependencies:

--- a/app/src/db/index.ts
+++ b/app/src/db/index.ts
@@ -2,8 +2,10 @@ import fs from 'fs';
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import * as sqliteVss from 'sqlite-vss';
 
 const sqlite = new Database(process.env.DATABASE_URL || './sqlite.db');
+sqliteVss.load(sqlite);
 export const db = drizzle(sqlite);
 
 if (fs.existsSync('./drizzle')) {


### PR DESCRIPTION
## Summary
- add sqlite-vss dependency
- auto-load sqlite-vss extension when opening the SQLite database
- document that sqlite-vss loads automatically

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve import `@/styled-system/css`)*
- `pnpm build` *(fails: Failed to collect page data for /api/upload-work)*

------
https://chatgpt.com/codex/tasks/task_e_686c0c356c44832bb4f3c08594c06d55