### PR TITLE
Fix TypeScript errors in tests

### DIFF
--- a/app/src/components/NavBar.test.tsx
+++ b/app/src/components/NavBar.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { NavBar } from './NavBar';
 import { useSession } from 'next-auth/react';
+import type { Mock } from 'vitest';
 
 vi.mock('next-auth/react', async () => {
   const actual = (await vi.importActual<typeof import('next-auth/react')>('next-auth/react'));
@@ -10,7 +11,7 @@ vi.mock('next-auth/react', async () => {
     signOut: vi.fn(),
   };
 });
-const mockedUseSession = useSession as unknown as vi.Mock;
+const mockedUseSession = useSession as unknown as Mock;
 
 test('shows sign in link when unauthenticated', () => {
   mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });

--- a/app/src/components/UploadedWorkList.test.tsx
+++ b/app/src/components/UploadedWorkList.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from '@testing-library/react'
 import { UploadedWorkList } from './UploadedWorkList'
+import type { Mock } from 'vitest'
 
 vi.stubGlobal('fetch', vi.fn())
 
-const mockFetch = fetch as unknown as vi.Mock
+const mockFetch = fetch as unknown as Mock
 
 interface Work { id: string; summary: string; dateUploaded: string; dateCompleted: string | null }
 

--- a/app/tests/e2e/uploadWork.test.ts
+++ b/app/tests/e2e/uploadWork.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, type Mock } from 'vitest';
 import { NextRequest } from 'next/server';
 import { POST as uploadWork, GET as getWorks } from '@/app/api/upload-work/route';
 import { getServerSession } from 'next-auth';
@@ -20,7 +20,7 @@ vi.mock('@/db', () => ({
 
 describe('upload-work API', () => {
   it('rejects unauthenticated users', async () => {
-    (getServerSession as unknown as vi.Mock).mockResolvedValue(null);
+    (getServerSession as unknown as Mock).mockResolvedValue(null);
     const form = new FormData();
     form.set('file', new File(['hello'], 'hello.txt'));
     form.set('studentId', '1');
@@ -30,7 +30,7 @@ describe('upload-work API', () => {
   });
 
   it('accepts valid data', async () => {
-    (getServerSession as unknown as vi.Mock).mockResolvedValue({ user: { id: 'u1' } });
+    (getServerSession as unknown as Mock).mockResolvedValue({ user: { id: 'u1' } });
     const form = new FormData();
     form.set('file', new File(['hello'], 'hello.txt'));
     form.set('studentId', '1');
@@ -41,9 +41,8 @@ describe('upload-work API', () => {
   });
 
   it('requires auth for GET', async () => {
-    (getServerSession as unknown as vi.Mock).mockResolvedValue(null);
-    const req = new NextRequest(new Request('http://localhost/api/upload-work'));
-    const res = await getWorks(req);
+    (getServerSession as unknown as Mock).mockResolvedValue(null);
+    const res = await getWorks();
     expect(res.status).toBe(401);
   });
 });

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -17,6 +17,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "types": ["vitest/globals"],
     "plugins": [
       {
         "name": "next"

--- a/app/vitest.shims.d.ts
+++ b/app/vitest.shims.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="@vitest/browser/providers/playwright" />
+/// <reference types="vitest" />


### PR DESCRIPTION
## Summary
- include vitest globals in `tsconfig.json`
- add vitest types reference
- update tests to use `Mock` type
- adjust GET test call

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: custom Babel config warning, build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686c0d0de6c0832b9ca3fa740706305a