### PR TITLE
Add student profile management

### DIFF
--- a/app/src/app/api/students/route.ts
+++ b/app/src/app/api/students/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { db } from '@/db'
+import { students, teacherStudents, users } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/authOptions'
+import { studentSchema } from '@/forms/student'
+
+export async function GET() {
+  const session = await getServerSession(authOptions)
+  const userId = (session?.user as { id?: string } | undefined)?.id
+  if (!userId) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  const rows = await db
+    .select({ id: students.id, name: students.name, email: students.email })
+    .from(teacherStudents)
+    .innerJoin(students, eq(teacherStudents.studentId, students.id))
+    .where(eq(teacherStudents.teacherId, userId))
+  return NextResponse.json({ students: rows })
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions)
+  const teacherId = (session?.user as { id?: string } | undefined)?.id
+  if (!teacherId) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  const data = studentSchema.parse(await req.json())
+  let accountId: string | null = null
+  if (data.email) {
+    const [user] = await db.select().from(users).where(eq(users.email, data.email))
+    if (user) accountId = user.id
+  }
+  const [student] = await db
+    .insert(students)
+    .values({ name: data.name, email: data.email, accountId })
+    .returning({ id: students.id })
+  await db.insert(teacherStudents).values({ teacherId, studentId: student.id })
+  return NextResponse.json({ student })
+}

--- a/app/src/app/students/page.tsx
+++ b/app/src/app/students/page.tsx
@@ -1,0 +1,22 @@
+import { StudentForm } from '@/components/StudentForm'
+import { StudentList } from '@/components/StudentList'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/authOptions'
+
+export default async function StudentsPage() {
+  const session = await getServerSession(authOptions)
+  const userId = (session?.user as { id?: string } | undefined)?.id
+  if (!userId) {
+    return <div style={{ padding: '2rem' }}>Please sign in</div>
+  }
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Students</h1>
+      <StudentList />
+      <h2>Add Student</h2>
+      <StudentForm onSubmit={async (data) => {
+        await fetch('/api/students', { method: 'POST', body: JSON.stringify(data) })
+      }} />
+    </div>
+  )
+}

--- a/app/src/components/StudentForm.stories.tsx
+++ b/app/src/components/StudentForm.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta } from '@storybook/react'
+import { StudentForm } from './StudentForm'
+
+const meta: Meta<typeof StudentForm> = {
+  title: 'StudentForm',
+  component: StudentForm,
+}
+export default meta
+
+export const Default = {}

--- a/app/src/components/StudentForm.test.tsx
+++ b/app/src/components/StudentForm.test.tsx
@@ -1,0 +1,13 @@
+import { render, fireEvent, screen } from '@testing-library/react'
+import { StudentForm } from './StudentForm'
+import '@testing-library/jest-dom'
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({}) }))
+
+describe('StudentForm', () => {
+  it('shows validation errors', async () => {
+    render(<StudentForm onSubmit={vi.fn()} />)
+    fireEvent.submit(screen.getByRole('button'))
+    expect(await screen.findByText('Name is required')).toBeInTheDocument()
+  })
+})

--- a/app/src/components/StudentForm.tsx
+++ b/app/src/components/StudentForm.tsx
@@ -1,0 +1,19 @@
+'use client'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { studentSchema, StudentFields } from '@/forms/student'
+
+export function StudentForm({ onSubmit }: { onSubmit: (data: StudentFields) => void }) {
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<StudentFields>({
+    resolver: zodResolver(studentSchema),
+  })
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      <input type="text" placeholder="Name" {...register('name')} />
+      {errors.name && <span>{errors.name.message}</span>}
+      <input type="email" placeholder="Email" {...register('email')} />
+      {errors.email && <span>{errors.email.message}</span>}
+      <button type="submit" disabled={isSubmitting}>Save</button>
+    </form>
+  )
+}

--- a/app/src/components/StudentList.stories.tsx
+++ b/app/src/components/StudentList.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta } from '@storybook/react'
+import { StudentList } from './StudentList'
+
+const meta: Meta<typeof StudentList> = {
+  title: 'StudentList',
+  component: StudentList,
+}
+export default meta
+
+export const Default = {}

--- a/app/src/components/StudentList.test.tsx
+++ b/app/src/components/StudentList.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react'
+import { StudentList } from './StudentList'
+import '@testing-library/jest-dom'
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({}) }))
+
+global.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ students: [] }) })) as unknown as typeof fetch
+
+describe('StudentList', () => {
+  it('renders', async () => {
+    render(<StudentList />)
+    expect(await screen.findByRole('list')).toBeInTheDocument()
+  })
+})

--- a/app/src/components/StudentList.tsx
+++ b/app/src/components/StudentList.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+type Student = { id: string; name: string; email: string | null }
+
+export function StudentList() {
+  const [students, setStudents] = useState<Student[]>([])
+  useEffect(() => {
+    fetch('/api/students')
+      .then((r) => r.json())
+      .then((d) => setStudents(d.students))
+  }, [])
+  return (
+    <ul>
+      {students.map((s) => (
+        <li key={s.id}>{s.name} {s.email}</li>
+      ))}
+    </ul>
+  )
+}

--- a/app/src/components/UploadForm.test.tsx
+++ b/app/src/components/UploadForm.test.tsx
@@ -3,6 +3,7 @@ import { UploadForm } from './UploadForm'
 import '@testing-library/jest-dom'
 
 vi.mock('next/navigation', () => ({ useRouter: () => ({}) }))
+global.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ students: [] }) })) as unknown as typeof fetch
 
 describe('UploadForm', () => {
   it('shows validation errors', async () => {

--- a/app/src/components/UploadForm.tsx
+++ b/app/src/components/UploadForm.tsx
@@ -3,6 +3,7 @@ import { css } from '@/styled-system/css'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { uploadWorkClientSchema, UploadWorkClient } from '@/forms/uploadWork'
+import { useEffect, useState } from 'react'
 
 interface Props {
   onUploadStart?: () => void
@@ -17,6 +18,13 @@ export function UploadForm({ onUploadStart, onSuccess, onError }: Props) {
     reset,
     formState: { errors, isSubmitting },
   } = useForm<UploadWorkClient>({ resolver: zodResolver(uploadWorkClientSchema) })
+
+  const [students, setStudents] = useState<{ id: string; name: string }[]>([])
+  useEffect(() => {
+    fetch('/api/students')
+      .then((r) => r.json())
+      .then((d) => setStudents(d.students))
+  }, [])
 
   const onSubmit = async (data: UploadWorkClient) => {
     onUploadStart?.()
@@ -44,7 +52,12 @@ export function UploadForm({ onUploadStart, onSuccess, onError }: Props) {
       <input type="file" data-testid="file" {...register('file')} />
       {errors.file && <span>{errors.file.message}</span>}
       <input type="date" {...register('dateCompleted')} />
-      <input type="text" placeholder="Student ID" {...register('studentId')} />
+      <select {...register('studentId')} defaultValue="">
+        <option value="" disabled>Select student</option>
+        {students.map((s) => (
+          <option key={s.id} value={s.id}>{s.name}</option>
+        ))}
+      </select>
       {errors.studentId && <span>{errors.studentId.message}</span>}
       <button type="submit" disabled={isSubmitting}>Upload</button>
     </form>

--- a/app/src/components/UploadedWorkList.test.tsx
+++ b/app/src/components/UploadedWorkList.test.tsx
@@ -18,6 +18,7 @@ describe('UploadedWorkList', () => {
   })
 
   it('loads works on mount', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ students: [] }) })
     mockGet([{ id: '1', summary: 'sum', dateUploaded: new Date().toISOString(), dateCompleted: null }])
     render(<UploadedWorkList />)
     expect(mockFetch).toHaveBeenCalledWith('/api/upload-work')

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -72,10 +72,26 @@ export const authenticators = sqliteTable(
 export const students = sqliteTable('student', {
   id: text('id').primaryKey().notNull().$defaultFn(() => crypto.randomUUID()),
   name: text('name').notNull(),
-  userId: text('userId')
-    .notNull()
-    .references(() => users.id, { onDelete: 'cascade' }),
+  email: text('email'),
+  accountId: text('accountId').references(() => users.id, {
+    onDelete: 'cascade',
+  }),
 });
+
+export const teacherStudents = sqliteTable(
+  'teacher_student',
+  {
+    teacherId: text('teacherId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    studentId: text('studentId')
+      .notNull()
+      .references(() => students.id, { onDelete: 'cascade' }),
+  },
+  (ts) => ({
+    pk: primaryKey(ts.teacherId, ts.studentId),
+  }),
+);
 
 export const uploadedWork = sqliteTable('uploaded_work', {
   id: text('id').primaryKey().notNull().$defaultFn(() => crypto.randomUUID()),

--- a/app/src/forms/student.ts
+++ b/app/src/forms/student.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+export const studentSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Invalid email').optional(),
+})
+
+export type StudentFields = z.infer<typeof studentSchema>


### PR DESCRIPTION
## Summary
- link teachers and students in new relationship table
- add API routes and React forms for managing students
- update upload form to select a student
- provide storybook stories and tests for new components

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: Could not locate the bindings file)*

------
https://chatgpt.com/codex/tasks/task_e_686c0e65d774832b90cc9491f6009e71