### PR TITLE
Implement student management and update upload flow

### DIFF
--- a/app/src/app/api/students/[id]/route.ts
+++ b/app/src/app/api/students/[id]/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { db } from '@/db'
+import { students, teacherStudents, users } from '@/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/authOptions'
+import { studentFieldsSchema } from '@/forms/student'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function PUT(req: NextRequest, context: any) {
+  const { params } = context as { params: { id: string } }
+  const session = await getServerSession(authOptions)
+  const teacherId = (session?.user as { id?: string } | undefined)?.id
+  if (!teacherId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+  const id = params.id
+  const link = await db
+    .select()
+    .from(teacherStudents)
+    .where(and(eq(teacherStudents.teacherId, teacherId), eq(teacherStudents.studentId, id)))
+  if (link.length === 0) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
+  const data = studentFieldsSchema.parse(await req.json())
+  const { name, email } = data
+  let accountUserId: string | null = null
+  if (email) {
+    const [u] = await db.select().from(users).where(eq(users.email, email))
+    if (u) accountUserId = u.id
+  }
+  await db
+    .update(students)
+    .set({ name, email: email || null, accountUserId })
+    .where(eq(students.id, id))
+  return NextResponse.json({ ok: true })
+}

--- a/app/src/app/api/students/route.ts
+++ b/app/src/app/api/students/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { db } from '@/db'
+import { students, teacherStudents, users } from '@/db/schema'
+import { eq } from 'drizzle-orm'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/authOptions'
+import { studentFieldsSchema } from '@/forms/student'
+
+export async function GET() {
+  const session = await getServerSession(authOptions)
+  const userId = (session?.user as { id?: string } | undefined)?.id
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+  const rows = await db
+    .select({ id: students.id, name: students.name, email: students.email })
+    .from(teacherStudents)
+    .innerJoin(students, eq(teacherStudents.studentId, students.id))
+    .where(eq(teacherStudents.teacherId, userId))
+  return NextResponse.json({ students: rows })
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions)
+  const teacherId = (session?.user as { id?: string } | undefined)?.id
+  if (!teacherId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+  const data = studentFieldsSchema.parse(await req.json())
+  const { name, email } = data
+  let accountUserId: string | null = null
+  if (email) {
+    const [u] = await db.select().from(users).where(eq(users.email, email))
+    if (u) {
+      accountUserId = u.id
+    }
+  }
+  const [{ id }] = await db
+    .insert(students)
+    .values({ name, email: email || null, accountUserId })
+    .returning({ id: students.id })
+  await db
+    .insert(teacherStudents)
+    .values({ teacherId, studentId: id })
+  return NextResponse.json({ id })
+}

--- a/app/src/app/api/upload-work/route.ts
+++ b/app/src/app/api/upload-work/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/db';
-import { uploadedWork, students } from '@/db/schema';
-import { eq } from 'drizzle-orm';
+import { uploadedWork, teacherStudents } from '@/db/schema';
+import { eq, and } from 'drizzle-orm';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/authOptions';
 import OpenAI from 'openai';
@@ -20,16 +20,17 @@ export async function POST(req: NextRequest) {
     dateCompleted: form.get('dateCompleted'),
   });
   const { studentId, dateCompleted } = fields;
-  const [student] = await db
+  const link = await db
     .select()
-    .from(students)
-    .where(eq(students.id, studentId));
-  if (!student) {
-    await db.insert(students).values({
-      id: studentId,
-      name: studentId,
-      userId: userId as string,
-    });
+    .from(teacherStudents)
+    .where(
+      and(
+        eq(teacherStudents.teacherId, userId as string),
+        eq(teacherStudents.studentId, studentId)
+      )
+    );
+  if (link.length === 0) {
+    return NextResponse.json({ error: 'invalid student' }, { status: 400 });
   }
   if (!(file instanceof File)) {
     return NextResponse.json({ error: 'file required' }, { status: 400 });

--- a/app/src/app/students/page.tsx
+++ b/app/src/app/students/page.tsx
@@ -1,0 +1,22 @@
+import { StudentManager } from '@/components/StudentManager'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/authOptions'
+
+export default async function StudentsPage() {
+  const session = await getServerSession(authOptions)
+  const userId = (session?.user as { id?: string } | undefined)?.id
+  if (!userId) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <h1>Students</h1>
+        <p>Please sign in to manage students.</p>
+      </div>
+    )
+  }
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Students</h1>
+      <StudentManager />
+    </div>
+  )
+}

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -38,6 +38,9 @@ export function NavBar() {
       <Link href="/uploaded-work" style={styles.link}>
         Uploaded Work
       </Link>
+      <Link href="/students" style={styles.link}>
+        Students
+      </Link>
       <div style={styles.spacer} />
       {session ? (
         <button style={styles.button} onClick={() => signOut()}>

--- a/app/src/components/StudentForm.stories.tsx
+++ b/app/src/components/StudentForm.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta } from '@storybook/react'
+import { StudentForm } from './StudentForm'
+
+const meta: Meta<typeof StudentForm> = {
+  title: 'StudentForm',
+  component: StudentForm,
+}
+export default meta
+
+export const Default = {}

--- a/app/src/components/StudentForm.test.tsx
+++ b/app/src/components/StudentForm.test.tsx
@@ -1,0 +1,13 @@
+import { render, fireEvent, screen } from '@testing-library/react'
+import { StudentForm } from './StudentForm'
+import '@testing-library/jest-dom'
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({}) }))
+
+describe('StudentForm', () => {
+  it('shows validation errors', async () => {
+    render(<StudentForm />)
+    fireEvent.submit(screen.getByRole('button'))
+    expect(await screen.findByText('Name is required')).toBeInTheDocument()
+  })
+})

--- a/app/src/components/StudentForm.tsx
+++ b/app/src/components/StudentForm.tsx
@@ -1,0 +1,52 @@
+'use client'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  studentFieldsSchema,
+  StudentFields,
+} from '@/forms/student'
+
+interface Props {
+  student?: { id: string; name: string; email: string | null }
+  onSuccess?: () => void
+}
+
+export function StudentForm({ student, onSuccess }: Props) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<StudentFields>({
+    resolver: zodResolver(studentFieldsSchema),
+    defaultValues: {
+      name: student?.name ?? '',
+      email: student?.email ?? undefined,
+    },
+  })
+
+  const onSubmit = async (data: StudentFields) => {
+    const res = await fetch(
+      student ? `/api/students/${student.id}` : '/api/students',
+      {
+        method: student ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      }
+    )
+    if (res.ok) {
+      onSuccess?.()
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+      <input placeholder="Name" {...register('name')} />
+      {errors.name && <span>{errors.name.message}</span>}
+      <input placeholder="Email" {...register('email')} />
+      {errors.email && <span>{errors.email.message}</span>}
+      <button type="submit" disabled={isSubmitting}>
+        {student ? 'Save' : 'Add'}
+      </button>
+    </form>
+  )
+}

--- a/app/src/components/StudentManager.tsx
+++ b/app/src/components/StudentManager.tsx
@@ -1,0 +1,38 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { StudentForm } from './StudentForm'
+
+interface Student {
+  id: string
+  name: string
+  email: string | null
+}
+
+export function StudentManager() {
+  const [students, setStudents] = useState<Student[]>([])
+
+  const load = async () => {
+    const res = await fetch('/api/students')
+    if (res.ok) {
+      const data = (await res.json()) as { students: Student[] }
+      setStudents(data.students)
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  return (
+    <div>
+      <StudentForm onSuccess={load} />
+      <ul>
+        {students.map((s) => (
+          <li key={s.id}>
+            <StudentForm student={s} onSuccess={load} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/src/components/UploadForm.test.tsx
+++ b/app/src/components/UploadForm.test.tsx
@@ -6,6 +6,9 @@ vi.mock('next/navigation', () => ({ useRouter: () => ({}) }))
 
 describe('UploadForm', () => {
   it('shows validation errors', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ students: [] }) }) as unknown as typeof fetch
     render(<UploadForm />)
     fireEvent.submit(screen.getByRole('button'))
     expect(await screen.findByText('File is required')).toBeInTheDocument()

--- a/app/src/components/UploadForm.tsx
+++ b/app/src/components/UploadForm.tsx
@@ -3,6 +3,7 @@ import { css } from '@/styled-system/css'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { uploadWorkClientSchema, UploadWorkClient } from '@/forms/uploadWork'
+import { useEffect, useState } from 'react'
 
 interface Props {
   onUploadStart?: () => void
@@ -11,6 +12,18 @@ interface Props {
 }
 
 export function UploadForm({ onUploadStart, onSuccess, onError }: Props) {
+  const [students, setStudents] = useState<{ id: string; name: string }[]>([])
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch('/api/students')
+      if (res.ok) {
+        const data = (await res.json()) as { students: { id: string; name: string }[] }
+        setStudents(data.students)
+      }
+    }
+    load()
+  }, [])
   const {
     register,
     handleSubmit,
@@ -44,7 +57,16 @@ export function UploadForm({ onUploadStart, onSuccess, onError }: Props) {
       <input type="file" data-testid="file" {...register('file')} />
       {errors.file && <span>{errors.file.message}</span>}
       <input type="date" {...register('dateCompleted')} />
-      <input type="text" placeholder="Student ID" {...register('studentId')} />
+      <select {...register('studentId')} defaultValue="">
+        <option value="" disabled>
+          Select student
+        </option>
+        {students.map((s) => (
+          <option key={s.id} value={s.id}>
+            {s.name}
+          </option>
+        ))}
+      </select>
       {errors.studentId && <span>{errors.studentId.message}</span>}
       <button type="submit" disabled={isSubmitting}>Upload</button>
     </form>

--- a/app/src/components/UploadedWorkList.test.tsx
+++ b/app/src/components/UploadedWorkList.test.tsx
@@ -18,9 +18,11 @@ describe('UploadedWorkList', () => {
   })
 
   it('loads works on mount', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ students: [] }) })
     mockGet([{ id: '1', summary: 'sum', dateUploaded: new Date().toISOString(), dateCompleted: null }])
     render(<UploadedWorkList />)
-    expect(mockFetch).toHaveBeenCalledWith('/api/upload-work')
+    expect(mockFetch).toHaveBeenNthCalledWith(1, '/api/students')
+    expect(mockFetch).toHaveBeenNthCalledWith(2, '/api/upload-work')
     expect(await screen.findByText('sum')).toBeInTheDocument()
   })
 

--- a/app/src/db/index.ts
+++ b/app/src/db/index.ts
@@ -6,6 +6,6 @@ import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 const sqlite = new Database(process.env.DATABASE_URL || './sqlite.db');
 export const db = drizzle(sqlite);
 
-if (fs.existsSync('./drizzle')) {
+if (fs.existsSync('./drizzle') && process.env.NODE_ENV !== 'production') {
   migrate(db, { migrationsFolder: './drizzle' });
 }

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -72,10 +72,26 @@ export const authenticators = sqliteTable(
 export const students = sqliteTable('student', {
   id: text('id').primaryKey().notNull().$defaultFn(() => crypto.randomUUID()),
   name: text('name').notNull(),
-  userId: text('userId')
-    .notNull()
-    .references(() => users.id, { onDelete: 'cascade' }),
+  email: text('email'),
+  accountUserId: text('accountUserId').references(() => users.id, {
+    onDelete: 'set null',
+  }),
 });
+
+export const teacherStudents = sqliteTable(
+  'teacher_student',
+  {
+    teacherId: text('teacherId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    studentId: text('studentId')
+      .notNull()
+      .references(() => students.id, { onDelete: 'cascade' }),
+  },
+  (ts) => ({
+    pk: primaryKey(ts.teacherId, ts.studentId),
+  })
+);
 
 export const uploadedWork = sqliteTable('uploaded_work', {
   id: text('id').primaryKey().notNull().$defaultFn(() => crypto.randomUUID()),

--- a/app/src/forms/student.ts
+++ b/app/src/forms/student.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+export const studentFieldsSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z
+    .string()
+    .email('Invalid email')
+    .optional()
+    .or(z.literal('')),
+})
+
+export const studentServerSchema = studentFieldsSchema.extend({
+  id: z.string().optional(),
+})
+
+export type StudentFields = z.infer<typeof studentFieldsSchema>
+export type StudentServer = z.infer<typeof studentServerSchema>


### PR DESCRIPTION
## Summary
- add students API and page
- create student form and manager components
- allow selecting students when uploading work
- add many-to-many schema for teachers and students
- update database initialization logic

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686c0e65d774832b90cc9491f6009e71