### PR TITLE
Integrate React Query provider

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@auth/drizzle-adapter": "^1.10.0",
     "@hookform/resolvers": "^3.3.1",
+    "@tanstack/react-query": "^5.81.5",
     "better-sqlite3": "^12.2.0",
     "casbin": "^5.38.0",
     "drizzle-kit": "^0.31.4",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.3.1
         version: 3.10.0(react-hook-form@7.60.0(react@19.1.0))
+      '@tanstack/react-query':
+        specifier: ^5.81.5
+        version: 5.81.5(react@19.1.0)
       better-sqlite3:
         specifier: ^12.2.0
         version: 12.2.0
@@ -2107,6 +2110,14 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tanstack/query-core@5.81.5':
+    resolution: {integrity: sha512-ZJOgCy/z2qpZXWaj/oxvodDx07XcQa9BF92c0oINjHkoqUPsmm3uG08HpTaviviZ/N9eP1f9CM7mKSEkIo7O1Q==}
+
+  '@tanstack/react-query@5.81.5':
+    resolution: {integrity: sha512-lOf2KqRRiYWpQT86eeeftAGnjuTR35myTP8MXyvHa81VlomoAWNEd8x5vkcAfQefu0qtYCvyqLropFZqgI2EQw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -12096,6 +12107,13 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@tanstack/query-core@5.81.5': {}
+
+  '@tanstack/react-query@5.81.5(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.81.5
+      react: 19.1.0
 
   '@testing-library/dom@10.4.0':
     dependencies:

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import "../styles/index.css";
 import "katex/dist/katex.min.css";
 import AuthProvider from "@/components/AuthProvider";
+import QueryProvider from "@/components/QueryProvider";
 import { NavBar } from "@/components/NavBar";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/authOptions";
@@ -21,10 +22,12 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <body>
-        <AuthProvider session={session}>
-          <NavBar />
-          {children}
-        </AuthProvider>
+        <QueryProvider>
+          <AuthProvider session={session}>
+            <NavBar />
+            {children}
+          </AuthProvider>
+        </QueryProvider>
       </body>
     </html>
   );

--- a/app/src/components/QueryProvider.stories.tsx
+++ b/app/src/components/QueryProvider.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import QueryProvider from './QueryProvider'
+
+const meta: Meta<typeof QueryProvider> = {
+  component: QueryProvider,
+}
+export default meta
+
+type Story = StoryObj<typeof QueryProvider>
+
+export const Default: Story = {
+  render: () => (
+    <QueryProvider>
+      <div>Content</div>
+    </QueryProvider>
+  ),
+}

--- a/app/src/components/QueryProvider.test.tsx
+++ b/app/src/components/QueryProvider.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import QueryProvider from './QueryProvider'
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
+  return { ...actual, QueryClientProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div> }
+})
+
+test('renders children', () => {
+  render(
+    <QueryProvider>
+      <span>child</span>
+    </QueryProvider>
+  )
+  expect(screen.getByText('child')).toBeInTheDocument()
+})

--- a/app/src/components/QueryProvider.tsx
+++ b/app/src/components/QueryProvider.tsx
@@ -1,0 +1,22 @@
+'use client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useState } from 'react'
+
+export default function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [client] = useState(
+    () => new QueryClient({
+      defaultOptions: {
+        queries: {
+          staleTime: 5 * 60 * 1000,
+          queryFn: async ({ queryKey }) => {
+            const path = String(queryKey[0])
+            const res = await fetch(`/api/${path}`)
+            if (!res.ok) throw new Error('Network response was not ok')
+            return res.json()
+          },
+        },
+      },
+    })
+  )
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}


### PR DESCRIPTION
## Summary
- install `@tanstack/react-query`
- create `QueryProvider` for wrapping the app
- use the provider in the root layout
- add story and test for the provider

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build` *(fails: SqliteError: no such table: uploaded_work_index)*

------
https://chatgpt.com/codex/tasks/task_e_686c57028bf4832b944523b8a2d34552