### PR TITLE
Add saved DAG feature

### DIFF
--- a/app/drizzle/0005_amusing_vance_astro.sql
+++ b/app/drizzle/0005_amusing_vance_astro.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `topic_dag` (
+	`id` text PRIMARY KEY NOT NULL,
+	`userId` text NOT NULL,
+	`topics` text NOT NULL,
+	`graph` text NOT NULL,
+	`dateCreated` integer NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint

--- a/app/drizzle/meta/0005_snapshot.json
+++ b/app/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,655 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "afbcf71c-4ecc-442b-bf4d-5e301f56e1a3",
+  "prevId": "54c73670-6a25-419c-8163-a70fb5f690c7",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "name": "account_provider_providerAccountId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authenticator": {
+      "name": "authenticator",
+      "columns": {
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialPublicKey": {
+          "name": "credentialPublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialDeviceType": {
+          "name": "credentialDeviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialBackedUp": {
+          "name": "credentialBackedUp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authenticator_credentialID_unique": {
+          "name": "authenticator_credentialID_unique",
+          "columns": [
+            "credentialID"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "authenticator_userId_user_id_fk": {
+          "name": "authenticator_userId_user_id_fk",
+          "tableFrom": "authenticator",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authenticator_userId_credentialID_pk": {
+          "columns": [
+            "userId",
+            "credentialID"
+          ],
+          "name": "authenticator_userId_credentialID_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "student": {
+      "name": "student",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accountUserId": {
+          "name": "accountUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_accountUserId_user_id_fk": {
+          "name": "student_accountUserId_user_id_fk",
+          "tableFrom": "student",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accountUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag": {
+      "name": "tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_text_unique": {
+          "name": "tag_text_unique",
+          "columns": [
+            "text"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teacher_student": {
+      "name": "teacher_student",
+      "columns": {
+        "teacherId": {
+          "name": "teacherId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "studentId": {
+          "name": "studentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teacher_student_teacherId_user_id_fk": {
+          "name": "teacher_student_teacherId_user_id_fk",
+          "tableFrom": "teacher_student",
+          "tableTo": "user",
+          "columnsFrom": [
+            "teacherId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teacher_student_studentId_student_id_fk": {
+          "name": "teacher_student_studentId_student_id_fk",
+          "tableFrom": "teacher_student",
+          "tableTo": "student",
+          "columnsFrom": [
+            "studentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teacher_student_teacherId_studentId_pk": {
+          "columns": [
+            "teacherId",
+            "studentId"
+          ],
+          "name": "teacher_student_teacherId_studentId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "topic_dag": {
+      "name": "topic_dag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dateCreated": {
+          "name": "dateCreated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "topic_dag_userId_user_id_fk": {
+          "name": "topic_dag_userId_user_id_fk",
+          "tableFrom": "topic_dag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "uploaded_work": {
+      "name": "uploaded_work",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "studentId": {
+          "name": "studentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dateUploaded": {
+          "name": "dateUploaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dateCompleted": {
+          "name": "dateCompleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embeddings": {
+          "name": "embeddings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "originalDocument": {
+          "name": "originalDocument",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "uploaded_work_userId_user_id_fk": {
+          "name": "uploaded_work_userId_user_id_fk",
+          "tableFrom": "uploaded_work",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploaded_work_studentId_student_id_fk": {
+          "name": "uploaded_work_studentId_student_id_fk",
+          "tableFrom": "uploaded_work",
+          "tableTo": "student",
+          "columnsFrom": [
+            "studentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verificationToken": {
+      "name": "verificationToken",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "columns": [
+            "identifier",
+            "token"
+          ],
+          "name": "verificationToken_identifier_token_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1751926284772,
       "tag": "0004_tag_index",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1751931358695,
+      "tag": "0005_amusing_vance_astro",
+      "breakpoints": true
     }
   ]
 }

--- a/app/src/app/api/dags/route.ts
+++ b/app/src/app/api/dags/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/db';
+import { topicDags } from '@/db/schema';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/authOptions';
+import { z } from 'zod';
+import { eq } from 'drizzle-orm';
+
+const dagSchema = z.object({
+  topics: z.array(z.string()),
+  graph: z.string(),
+});
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const userId = (session?.user as { id?: string } | undefined)?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const { topics, graph } = dagSchema.parse(await req.json());
+  const [{ id }] = await db
+    .insert(topicDags)
+    .values({
+      userId,
+      topics: JSON.stringify(topics),
+      graph,
+      dateCreated: new Date(),
+    })
+    .returning({ id: topicDags.id });
+  return NextResponse.json({ id });
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  const userId = (session?.user as { id?: string } | undefined)?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const rows = await db
+    .select()
+    .from(topicDags)
+    .where(eq(topicDags.userId, userId));
+  const dags = rows.map((d) => ({
+    ...d,
+    topics: JSON.parse(d.topics as string) as string[],
+  }));
+  return NextResponse.json({ dags });
+}

--- a/app/src/app/dags/page.tsx
+++ b/app/src/app/dags/page.tsx
@@ -1,0 +1,22 @@
+import { DagList } from '@/components/DagList'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/authOptions'
+
+export default async function DagsPage() {
+  const session = await getServerSession(authOptions)
+  const userId = (session?.user as { id?: string } | undefined)?.id
+  if (!userId) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <h1>Saved Graphs</h1>
+        <p>Please sign in to view your graphs.</p>
+      </div>
+    )
+  }
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Saved Graphs</h1>
+      <DagList />
+    </div>
+  )
+}

--- a/app/src/components/DagList.stories.tsx
+++ b/app/src/components/DagList.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta } from '@storybook/react'
+import { DagList } from './DagList'
+
+const meta: Meta<typeof DagList> = {
+  title: 'DagList',
+  component: DagList,
+}
+export default meta
+
+export const Default = {}

--- a/app/src/components/DagList.test.tsx
+++ b/app/src/components/DagList.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import { DagList } from './DagList'
+import type { Mock } from 'vitest'
+
+vi.stubGlobal('fetch', vi.fn())
+const mockFetch = fetch as unknown as Mock
+
+interface Dag { id: string; topics: string[]; graph: string; dateCreated: string }
+function mockGet(dags: Dag[]) {
+  mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ dags }) })
+}
+
+describe('DagList', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  it('loads dags on mount', async () => {
+    mockGet([{ id: '1', topics: ['A'], graph: '', dateCreated: new Date().toISOString() }])
+    render(<DagList />)
+    expect(mockFetch).toHaveBeenCalledWith('/api/dags')
+    expect(await screen.findByText((t) => t.includes('A'))).toBeInTheDocument()
+  })
+})

--- a/app/src/components/DagList.tsx
+++ b/app/src/components/DagList.tsx
@@ -1,0 +1,42 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+interface Dag {
+  id: string
+  topics: string[]
+  graph: string
+  dateCreated: string
+}
+
+export function DagList() {
+  const [dags, setDags] = useState<Dag[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  const load = async () => {
+    try {
+      const res = await fetch('/api/dags')
+      if (!res.ok) throw new Error('failed')
+      const data = (await res.json()) as { dags: Dag[] }
+      setDags(data.dags)
+    } catch {
+      setError('Failed to load DAGs')
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  return (
+    <div>
+      {error && <p>{error}</p>}
+      <ul>
+        {dags.map((d) => (
+          <li key={d.id} style={{ marginBottom: '1rem' }}>
+            <strong>{new Date(d.dateCreated).toLocaleDateString()}</strong>: {d.topics.join(', ')}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/src/components/MathSkillSelector.test.tsx
+++ b/app/src/components/MathSkillSelector.test.tsx
@@ -1,12 +1,20 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import type { Mock } from 'vitest';
 vi.mock('react-mermaid2', () => ({ default: () => <div data-testid="mermaid" /> }));
 import { MathSkillSelector } from './MathSkillSelector';
 
-vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ graph: 'g' }) }));
+vi.stubGlobal('fetch', vi.fn());
+const mockFetch = fetch as unknown as Mock;
 
-test('calls API with selected topics', async () => {
+test('calls API with selected topics and saves', async () => {
+  mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ graph: 'g' }) });
+  mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ id: '1' }) });
   render(<MathSkillSelector />);
   fireEvent.click(screen.getByLabelText('Algebra'));
   fireEvent.click(screen.getByText('Generate Graph'));
-  expect(fetch).toHaveBeenCalledWith('/api/generate-graph', expect.objectContaining({ method: 'POST' }));
+  await screen.findByTestId('mermaid');
+  fireEvent.click(screen.getByText('Save Graph'));
+  await screen.findByText('Saved!');
+  expect(mockFetch).toHaveBeenNthCalledWith(1, '/api/generate-graph', expect.objectContaining({ method: 'POST' }));
+  expect(mockFetch).toHaveBeenNthCalledWith(2, '/api/dags', expect.objectContaining({ method: 'POST' }));
 });

--- a/app/src/components/MathSkillSelector.tsx
+++ b/app/src/components/MathSkillSelector.tsx
@@ -28,6 +28,7 @@ const skills = [
 export function MathSkillSelector() {
   const [selected, setSelected] = useState<string[]>([]);
   const [graph, setGraph] = useState('');
+  const [savedId, setSavedId] = useState<string | null>(null);
 
   const toggle = (skill: string) => {
     setSelected((prev) =>
@@ -44,6 +45,19 @@ export function MathSkillSelector() {
     if (res.ok) {
       const data = (await res.json()) as { graph: string };
       setGraph(data.graph);
+      setSavedId(null);
+    }
+  };
+
+  const save = async () => {
+    const res = await fetch('/api/dags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ topics: selected, graph }),
+    });
+    if (res.ok) {
+      const data = (await res.json()) as { id: string };
+      setSavedId(data.id);
     }
   };
 
@@ -64,12 +78,18 @@ export function MathSkillSelector() {
       <button style={styles.button} onClick={generate}>
         Generate Graph
       </button>
-        {graph && (
+      {graph && (
+        <>
           <div id="graph-container" style={styles.graph}>
             {/* re-mount Mermaid when chart string changes to ensure re-render */}
             <Mermaid key={graph} chart={graph} />
           </div>
-        )}
+          <button style={styles.button} onClick={save}>
+            Save Graph
+          </button>
+          {savedId && <p>Saved!</p>}
+        </>
+      )}
     </div>
   );
 }

--- a/app/src/components/NavBar.test.tsx
+++ b/app/src/components/NavBar.test.tsx
@@ -30,3 +30,9 @@ test('shows uploaded work link', () => {
   render(<NavBar />);
   expect(screen.getByText('Uploaded Work')).toBeInTheDocument();
 });
+
+test('shows my graphs link', () => {
+  mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+  render(<NavBar />);
+  expect(screen.getByText('My Graphs')).toBeInTheDocument();
+});

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -41,6 +41,9 @@ export function NavBar() {
       <Link href="/students" style={styles.link}>
         Students
       </Link>
+      <Link href="/dags" style={styles.link}>
+        My Graphs
+      </Link>
       <div style={styles.spacer} />
       {session ? (
         <button style={styles.button} onClick={() => signOut()}>

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -116,3 +116,15 @@ export const tags = sqliteTable('tag', {
   text: text('text').notNull().unique(),
 });
 
+export const topicDags = sqliteTable('topic_dag', {
+  id: text('id').primaryKey().notNull().$defaultFn(() => crypto.randomUUID()),
+  userId: text('userId')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  topics: text('topics').notNull(),
+  graph: text('graph').notNull(),
+  dateCreated: integer('dateCreated', { mode: 'timestamp_ms' })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+

--- a/app/tests/e2e/dags.test.ts
+++ b/app/tests/e2e/dags.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, type Mock } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST, GET } from '@/app/api/dags/route'
+import { getServerSession } from 'next-auth'
+
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }))
+vi.mock('@/authOptions', () => ({ authOptions: {} }))
+vi.mock('@/db', () => ({
+  db: {
+    insert: vi.fn(() => ({ values: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: '1' }]) })) })),
+    select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([{ id: '1', userId: 'u1', topics: '[]', graph: 'g', dateCreated: new Date().toISOString() }]) })) }))
+  }
+}))
+
+describe('dags API', () => {
+  it('requires auth on POST', async () => {
+    (getServerSession as unknown as Mock).mockResolvedValue(null)
+    const req = new NextRequest(new Request('http://localhost/api/dags', { method: 'POST', body: '{}' }))
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns dags for GET', async () => {
+    (getServerSession as unknown as Mock).mockResolvedValue({ user: { id: 'u1' } })
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.dags.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- allow saving generated graphs to a new `topic_dag` table
- expose `/api/dags` route for creating and listing DAGs
- list saved graphs on new `/dags` page
- show "My Graphs" link in the NavBar
- add `DagList` component with stories and tests
- update `MathSkillSelector` to save graphs
- add migration for `topic_dag`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: SqliteError: no such table: uploaded_work_index)*
- `pnpm typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686c583c5548832bac7b443819d770ba