### PR TITLE
Add Topic DAG persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A web application for planning and tracking long term learning goals. Users define topic graphs and upload work samples. The app stores metadata and embeddings to recommend what to study next.
 
-Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**. The navigation bar also links to the **Uploaded Work** page.
+Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**. The navigation bar also links to the **Uploaded Work** page and the **Saved DAGs** page.
 
 The home page includes a math skill selector that generates a mermaid DAG of prerequisites using the built-in LLM client.
 
@@ -83,6 +83,10 @@ Authenticated users can upload documents from the **Uploaded Work** page. The se
 New uploads appear immediately in the list with a temporary "Processing..." placeholder while the LLM generates the summary. Any upload errors are shown next to the list.
 
 Math expressions wrapped in `$...$`, `$$...$$`, `\(...\)` or `\[...\]` in summaries are rendered with KaTeX.
+
+## Saved DAGs
+
+The **Saved DAGs** page lists every topic graph you've generated and saved from the home page. Each entry shows when it was created and which topics were included.
 
 ## Tag Generation
 

--- a/app/drizzle/0005_salty_wolfsbane.sql
+++ b/app/drizzle/0005_salty_wolfsbane.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `topic_dag` (
+	`id` text PRIMARY KEY NOT NULL,
+	`userId` text NOT NULL,
+	`topics` text NOT NULL,
+	`graph` text NOT NULL,
+	`createdAt` integer NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/app/drizzle/meta/0005_snapshot.json
+++ b/app/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,655 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8c849e10-c359-42b2-b0da-81c21def18b5",
+  "prevId": "54c73670-6a25-419c-8163-a70fb5f690c7",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "name": "account_provider_providerAccountId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authenticator": {
+      "name": "authenticator",
+      "columns": {
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialPublicKey": {
+          "name": "credentialPublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialDeviceType": {
+          "name": "credentialDeviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialBackedUp": {
+          "name": "credentialBackedUp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authenticator_credentialID_unique": {
+          "name": "authenticator_credentialID_unique",
+          "columns": [
+            "credentialID"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "authenticator_userId_user_id_fk": {
+          "name": "authenticator_userId_user_id_fk",
+          "tableFrom": "authenticator",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authenticator_userId_credentialID_pk": {
+          "columns": [
+            "userId",
+            "credentialID"
+          ],
+          "name": "authenticator_userId_credentialID_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "student": {
+      "name": "student",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accountUserId": {
+          "name": "accountUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_accountUserId_user_id_fk": {
+          "name": "student_accountUserId_user_id_fk",
+          "tableFrom": "student",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accountUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag": {
+      "name": "tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_text_unique": {
+          "name": "tag_text_unique",
+          "columns": [
+            "text"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teacher_student": {
+      "name": "teacher_student",
+      "columns": {
+        "teacherId": {
+          "name": "teacherId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "studentId": {
+          "name": "studentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teacher_student_teacherId_user_id_fk": {
+          "name": "teacher_student_teacherId_user_id_fk",
+          "tableFrom": "teacher_student",
+          "tableTo": "user",
+          "columnsFrom": [
+            "teacherId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teacher_student_studentId_student_id_fk": {
+          "name": "teacher_student_studentId_student_id_fk",
+          "tableFrom": "teacher_student",
+          "tableTo": "student",
+          "columnsFrom": [
+            "studentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teacher_student_teacherId_studentId_pk": {
+          "columns": [
+            "teacherId",
+            "studentId"
+          ],
+          "name": "teacher_student_teacherId_studentId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "topic_dag": {
+      "name": "topic_dag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "topic_dag_userId_user_id_fk": {
+          "name": "topic_dag_userId_user_id_fk",
+          "tableFrom": "topic_dag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "uploaded_work": {
+      "name": "uploaded_work",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "studentId": {
+          "name": "studentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dateUploaded": {
+          "name": "dateUploaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dateCompleted": {
+          "name": "dateCompleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embeddings": {
+          "name": "embeddings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "originalDocument": {
+          "name": "originalDocument",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "uploaded_work_userId_user_id_fk": {
+          "name": "uploaded_work_userId_user_id_fk",
+          "tableFrom": "uploaded_work",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploaded_work_studentId_student_id_fk": {
+          "name": "uploaded_work_studentId_student_id_fk",
+          "tableFrom": "uploaded_work",
+          "tableTo": "student",
+          "columnsFrom": [
+            "studentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verificationToken": {
+      "name": "verificationToken",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "columns": [
+            "identifier",
+            "token"
+          ],
+          "name": "verificationToken_identifier_token_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1751926284772,
       "tag": "0004_tag_index",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1751931141170,
+      "tag": "0005_salty_wolfsbane",
+      "breakpoints": true
     }
   ]
 }

--- a/app/src/app/api/topic-dags/route.ts
+++ b/app/src/app/api/topic-dags/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/db';
+import { topicDags } from '@/db/schema';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/authOptions';
+import { z } from 'zod';
+import { eq } from 'drizzle-orm';
+
+const postSchema = z.object({ topics: z.array(z.string()), graph: z.string() });
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const userId = (session?.user as { id?: string } | undefined)?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const data = postSchema.parse(await req.json());
+  await db.insert(topicDags).values({
+    userId,
+    topics: JSON.stringify(data.topics),
+    graph: data.graph,
+    createdAt: new Date(),
+  });
+  return NextResponse.json({ ok: true });
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  const userId = (session?.user as { id?: string } | undefined)?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const rows = await db
+    .select()
+    .from(topicDags)
+    .where(eq(topicDags.userId, userId));
+  return NextResponse.json({ dags: rows });
+}

--- a/app/src/app/topic-dags/page.tsx
+++ b/app/src/app/topic-dags/page.tsx
@@ -1,0 +1,22 @@
+import { TopicDAGList } from '@/components/TopicDAGList'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/authOptions'
+
+export default async function TopicDAGsPage() {
+  const session = await getServerSession(authOptions)
+  const userId = (session?.user as { id?: string } | undefined)?.id
+  if (!userId) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <h1>Saved DAGs</h1>
+        <p>Please sign in to view your DAGs.</p>
+      </div>
+    )
+  }
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Saved DAGs</h1>
+      <TopicDAGList />
+    </div>
+  )
+}

--- a/app/src/components/MathSkillSelector.test.tsx
+++ b/app/src/components/MathSkillSelector.test.tsx
@@ -1,12 +1,20 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import type { Mock } from 'vitest';
 vi.mock('react-mermaid2', () => ({ default: () => <div data-testid="mermaid" /> }));
 import { MathSkillSelector } from './MathSkillSelector';
 
-vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ graph: 'g' }) }));
+vi.stubGlobal('fetch', vi.fn());
+const mockFetch = fetch as unknown as Mock;
 
-test('calls API with selected topics', async () => {
+test('calls API with selected topics and saves', async () => {
+  mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ graph: 'g' }) });
+  mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ok: true }) });
   render(<MathSkillSelector />);
   fireEvent.click(screen.getByLabelText('Algebra'));
   fireEvent.click(screen.getByText('Generate Graph'));
-  expect(fetch).toHaveBeenCalledWith('/api/generate-graph', expect.objectContaining({ method: 'POST' }));
+  expect(mockFetch).toHaveBeenCalledWith('/api/generate-graph', expect.objectContaining({ method: 'POST' }));
+  // wait for graph to render
+  await screen.findByTestId('mermaid');
+  fireEvent.click(screen.getByText('Save Graph'));
+  expect(mockFetch).toHaveBeenLastCalledWith('/api/topic-dags', expect.objectContaining({ method: 'POST' }));
 });

--- a/app/src/components/MathSkillSelector.tsx
+++ b/app/src/components/MathSkillSelector.tsx
@@ -28,6 +28,7 @@ const skills = [
 export function MathSkillSelector() {
   const [selected, setSelected] = useState<string[]>([]);
   const [graph, setGraph] = useState('');
+  const [saved, setSaved] = useState(false);
 
   const toggle = (skill: string) => {
     setSelected((prev) =>
@@ -44,6 +45,18 @@ export function MathSkillSelector() {
     if (res.ok) {
       const data = (await res.json()) as { graph: string };
       setGraph(data.graph);
+      setSaved(false);
+    }
+  };
+
+  const save = async () => {
+    const res = await fetch('/api/topic-dags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ topics: selected, graph }),
+    });
+    if (res.ok) {
+      setSaved(true);
     }
   };
 
@@ -64,9 +77,14 @@ export function MathSkillSelector() {
       <button style={styles.button} onClick={generate}>
         Generate Graph
       </button>
-        {graph && (
-          <div id="graph-container" style={styles.graph}>
-            {/* re-mount Mermaid when chart string changes to ensure re-render */}
+      {graph && (
+        <button style={styles.button} onClick={save} disabled={saved}>
+          {saved ? 'Saved' : 'Save Graph'}
+        </button>
+      )}
+      {graph && (
+        <div id="graph-container" style={styles.graph}>
+          {/* re-mount Mermaid when chart string changes to ensure re-render */}
             <Mermaid key={graph} chart={graph} />
           </div>
         )}

--- a/app/src/components/NavBar.test.tsx
+++ b/app/src/components/NavBar.test.tsx
@@ -30,3 +30,9 @@ test('shows uploaded work link', () => {
   render(<NavBar />);
   expect(screen.getByText('Uploaded Work')).toBeInTheDocument();
 });
+
+test('shows saved dags link', () => {
+  mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+  render(<NavBar />);
+  expect(screen.getByText('Saved DAGs')).toBeInTheDocument();
+});

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -38,6 +38,9 @@ export function NavBar() {
       <Link href="/uploaded-work" style={styles.link}>
         Uploaded Work
       </Link>
+      <Link href="/topic-dags" style={styles.link}>
+        Saved DAGs
+      </Link>
       <Link href="/students" style={styles.link}>
         Students
       </Link>

--- a/app/src/components/TopicDAGList.stories.tsx
+++ b/app/src/components/TopicDAGList.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta } from '@storybook/react'
+import { TopicDAGList } from './TopicDAGList'
+
+const meta: Meta<typeof TopicDAGList> = {
+  title: 'TopicDAGList',
+  component: TopicDAGList,
+}
+export default meta
+
+export const Default = {}

--- a/app/src/components/TopicDAGList.test.tsx
+++ b/app/src/components/TopicDAGList.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import { TopicDAGList } from './TopicDAGList'
+import type { Mock } from 'vitest'
+
+vi.stubGlobal('fetch', vi.fn())
+const mockFetch = fetch as unknown as Mock
+
+interface Dag { id: string; topics: string; graph: string; createdAt: string }
+
+function mockGet(dags: Dag[]) {
+  mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ dags }) })
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+test('loads DAGs on mount', async () => {
+  mockGet([{ id: '1', topics: JSON.stringify(['A', 'B']), graph: 'g', createdAt: new Date().toISOString() }])
+  render(<TopicDAGList />)
+  expect(mockFetch).toHaveBeenCalledWith('/api/topic-dags')
+  expect(await screen.findByText('A, B')).toBeInTheDocument()
+})

--- a/app/src/components/TopicDAGList.tsx
+++ b/app/src/components/TopicDAGList.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+interface Dag {
+  id: string
+  topics: string
+  graph: string
+  createdAt: string
+}
+
+export function TopicDAGList() {
+  const [dags, setDags] = useState<Dag[]>([])
+
+  const load = async () => {
+    const res = await fetch('/api/topic-dags')
+    if (res.ok) {
+      const data = (await res.json()) as { dags: Dag[] }
+      setDags(data.dags)
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  return (
+    <ul>
+      {dags.map((d) => (
+        <li key={d.id} style={{ marginBottom: '1rem' }}>
+          <strong>{new Date(d.createdAt).toLocaleString()}</strong>
+          <div>{JSON.parse(d.topics).join(', ')}</div>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -116,3 +116,15 @@ export const tags = sqliteTable('tag', {
   text: text('text').notNull().unique(),
 });
 
+export const topicDags = sqliteTable('topic_dag', {
+  id: text('id').primaryKey().notNull().$defaultFn(() => crypto.randomUUID()),
+  userId: text('userId')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  topics: text('topics').notNull(),
+  graph: text('graph').notNull(),
+  createdAt: integer('createdAt', { mode: 'timestamp_ms' })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+


### PR DESCRIPTION
## Summary
- save topic DAGs for each user
- show saved DAGs via new API route and page
- add navigation link to Saved DAGs
- display saved DAGs with creation date and topics
- update README
- add Storybook stories and tests
- generate schema migration

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build` *(fails: no such table: uploaded_work_index)*

------
https://chatgpt.com/codex/tasks/task_e_686c583c5548832bac7b443819d770ba