### PR TITLE
Add topic DAG saving and list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A web application for planning and tracking long term learning goals. Users defi
 
 Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**. The navigation bar also links to the **Uploaded Work** page.
 
-The home page includes a math skill selector that generates a mermaid DAG of prerequisites using the built-in LLM client.
+The home page includes a math skill selector that generates a mermaid DAG of prerequisites using the built-in LLM client. After generating a graph you can save it and review all of your saved DAGs from the **Topic DAGs** page in the navigation bar.
 
 ## Tech Stack
 
@@ -76,6 +76,10 @@ pnpm storybook
 Ensure all tests pass and lint using Biome before submitting PRs. See `AGENTS.md` for automation guidelines.
 Run `pnpm lint` to check formatting and linting or `pnpm format` to apply fixes.
 Remaining tasks and future work are documented in `TASKS.md`.
+
+## Topic DAGs
+
+After generating a prerequisite graph on the home page you can save it. The **Topic DAGs** page lists every graph you've saved with the creation date and the topics used to generate it.
 
 ## Uploaded Work
 

--- a/app/drizzle/0005_noisy_the_order.sql
+++ b/app/drizzle/0005_noisy_the_order.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `topic_dag` (
+	`id` text PRIMARY KEY NOT NULL,
+	`userId` text NOT NULL,
+	`topics` text NOT NULL,
+	`graph` text NOT NULL,
+	`createdAt` integer NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/app/drizzle/meta/0005_snapshot.json
+++ b/app/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,655 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "faf1cf60-f547-4993-81a6-668a95eb855a",
+  "prevId": "54c73670-6a25-419c-8163-a70fb5f690c7",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "name": "account_provider_providerAccountId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authenticator": {
+      "name": "authenticator",
+      "columns": {
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialPublicKey": {
+          "name": "credentialPublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialDeviceType": {
+          "name": "credentialDeviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialBackedUp": {
+          "name": "credentialBackedUp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authenticator_credentialID_unique": {
+          "name": "authenticator_credentialID_unique",
+          "columns": [
+            "credentialID"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "authenticator_userId_user_id_fk": {
+          "name": "authenticator_userId_user_id_fk",
+          "tableFrom": "authenticator",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authenticator_userId_credentialID_pk": {
+          "columns": [
+            "userId",
+            "credentialID"
+          ],
+          "name": "authenticator_userId_credentialID_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "student": {
+      "name": "student",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accountUserId": {
+          "name": "accountUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_accountUserId_user_id_fk": {
+          "name": "student_accountUserId_user_id_fk",
+          "tableFrom": "student",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accountUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag": {
+      "name": "tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_text_unique": {
+          "name": "tag_text_unique",
+          "columns": [
+            "text"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teacher_student": {
+      "name": "teacher_student",
+      "columns": {
+        "teacherId": {
+          "name": "teacherId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "studentId": {
+          "name": "studentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teacher_student_teacherId_user_id_fk": {
+          "name": "teacher_student_teacherId_user_id_fk",
+          "tableFrom": "teacher_student",
+          "tableTo": "user",
+          "columnsFrom": [
+            "teacherId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teacher_student_studentId_student_id_fk": {
+          "name": "teacher_student_studentId_student_id_fk",
+          "tableFrom": "teacher_student",
+          "tableTo": "student",
+          "columnsFrom": [
+            "studentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teacher_student_teacherId_studentId_pk": {
+          "columns": [
+            "teacherId",
+            "studentId"
+          ],
+          "name": "teacher_student_teacherId_studentId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "topic_dag": {
+      "name": "topic_dag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "topic_dag_userId_user_id_fk": {
+          "name": "topic_dag_userId_user_id_fk",
+          "tableFrom": "topic_dag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "uploaded_work": {
+      "name": "uploaded_work",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "studentId": {
+          "name": "studentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dateUploaded": {
+          "name": "dateUploaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dateCompleted": {
+          "name": "dateCompleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embeddings": {
+          "name": "embeddings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "originalDocument": {
+          "name": "originalDocument",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "uploaded_work_userId_user_id_fk": {
+          "name": "uploaded_work_userId_user_id_fk",
+          "tableFrom": "uploaded_work",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploaded_work_studentId_student_id_fk": {
+          "name": "uploaded_work_studentId_student_id_fk",
+          "tableFrom": "uploaded_work",
+          "tableTo": "student",
+          "columnsFrom": [
+            "studentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verificationToken": {
+      "name": "verificationToken",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "columns": [
+            "identifier",
+            "token"
+          ],
+          "name": "verificationToken_identifier_token_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1751926284772,
       "tag": "0004_tag_index",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1751931118190,
+      "tag": "0005_noisy_the_order",
+      "breakpoints": true
     }
   ]
 }

--- a/app/src/app/api/topic-dags/route.ts
+++ b/app/src/app/api/topic-dags/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/db';
+import { topicDags } from '@/db/schema';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/authOptions';
+import { z } from 'zod';
+import { eq } from 'drizzle-orm';
+
+const saveSchema = z.object({ topics: z.array(z.string()), graph: z.string() });
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const userId = (session?.user as { id?: string } | undefined)?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const json = await req.json();
+  const { topics, graph } = saveSchema.parse(json);
+  await db.insert(topicDags).values({
+    userId,
+    topics: JSON.stringify(topics),
+    graph,
+    createdAt: new Date(),
+  } as typeof topicDags.$inferInsert);
+  return NextResponse.json({ ok: true });
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  const userId = (session?.user as { id?: string } | undefined)?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const dags = await db
+    .select()
+    .from(topicDags)
+    .where(eq(topicDags.userId, userId));
+  return NextResponse.json({ dags });
+}

--- a/app/src/app/topic-dags/page.tsx
+++ b/app/src/app/topic-dags/page.tsx
@@ -1,0 +1,22 @@
+import { DagList } from '@/components/DagList'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/authOptions'
+
+export default async function TopicDagsPage() {
+  const session = await getServerSession(authOptions)
+  const userId = (session?.user as { id?: string } | undefined)?.id
+  if (!userId) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <h1>Topic DAGs</h1>
+        <p>Please sign in to view your DAGs.</p>
+      </div>
+    )
+  }
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Topic DAGs</h1>
+      <DagList />
+    </div>
+  )
+}

--- a/app/src/components/DagList.stories.tsx
+++ b/app/src/components/DagList.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta } from '@storybook/react'
+import { DagList } from './DagList'
+
+const meta: Meta<typeof DagList> = {
+  title: 'DagList',
+  component: DagList,
+}
+export default meta
+
+export const Default = {}

--- a/app/src/components/DagList.test.tsx
+++ b/app/src/components/DagList.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { DagList } from './DagList'
+import type { Mock } from 'vitest'
+
+vi.stubGlobal('fetch', vi.fn())
+const mockFetch = fetch as unknown as Mock
+
+const sample = [
+  { id: '1', topics: JSON.stringify(['a','b']), graph: 'g', createdAt: new Date().toISOString() }
+]
+
+it('loads dags on mount', async () => {
+  mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ dags: sample }) })
+  render(<DagList />)
+  expect(mockFetch).toHaveBeenCalledWith('/api/topic-dags')
+  expect(await screen.findByText('a, b')).toBeInTheDocument()
+})

--- a/app/src/components/DagList.tsx
+++ b/app/src/components/DagList.tsx
@@ -1,0 +1,30 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+interface Dag {
+  id: string
+  topics: string
+  graph: string
+  createdAt: string
+}
+
+export function DagList() {
+  const [dags, setDags] = useState<Dag[]>([])
+  useEffect(() => {
+    fetch('/api/topic-dags')
+      .then((res) => res.ok ? res.json() : Promise.reject())
+      .then((data: { dags: Dag[] }) => setDags(data.dags))
+      .catch(() => setDags([]))
+  }, [])
+
+  return (
+    <ul>
+      {dags.map((d) => (
+        <li key={d.id} style={{ marginBottom: '1rem' }}>
+          <strong>{new Date(d.createdAt).toLocaleString()}</strong>
+          <div>{JSON.parse(d.topics).join(', ')}</div>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/app/src/components/MathSkillSelector.test.tsx
+++ b/app/src/components/MathSkillSelector.test.tsx
@@ -9,4 +9,7 @@ test('calls API with selected topics', async () => {
   fireEvent.click(screen.getByLabelText('Algebra'));
   fireEvent.click(screen.getByText('Generate Graph'));
   expect(fetch).toHaveBeenCalledWith('/api/generate-graph', expect.objectContaining({ method: 'POST' }));
+  expect(await screen.findByText('Save Graph')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Save Graph'));
+  expect(fetch).toHaveBeenCalledWith('/api/topic-dags', expect.objectContaining({ method: 'POST' }));
 });

--- a/app/src/components/MathSkillSelector.tsx
+++ b/app/src/components/MathSkillSelector.tsx
@@ -28,6 +28,7 @@ const skills = [
 export function MathSkillSelector() {
   const [selected, setSelected] = useState<string[]>([]);
   const [graph, setGraph] = useState('');
+  const [saved, setSaved] = useState(false);
 
   const toggle = (skill: string) => {
     setSelected((prev) =>
@@ -44,6 +45,18 @@ export function MathSkillSelector() {
     if (res.ok) {
       const data = (await res.json()) as { graph: string };
       setGraph(data.graph);
+      setSaved(false);
+    }
+  };
+
+  const save = async () => {
+    const res = await fetch('/api/topic-dags', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ topics: selected, graph }),
+    });
+    if (res.ok) {
+      setSaved(true);
     }
   };
 
@@ -64,9 +77,14 @@ export function MathSkillSelector() {
       <button style={styles.button} onClick={generate}>
         Generate Graph
       </button>
-        {graph && (
-          <div id="graph-container" style={styles.graph}>
-            {/* re-mount Mermaid when chart string changes to ensure re-render */}
+      {graph && (
+        <button style={styles.button} onClick={save} disabled={saved}>
+          {saved ? 'Saved' : 'Save Graph'}
+        </button>
+      )}
+      {graph && (
+        <div id="graph-container" style={styles.graph}>
+          {/* re-mount Mermaid when chart string changes to ensure re-render */}
             <Mermaid key={graph} chart={graph} />
           </div>
         )}

--- a/app/src/components/NavBar.test.tsx
+++ b/app/src/components/NavBar.test.tsx
@@ -30,3 +30,9 @@ test('shows uploaded work link', () => {
   render(<NavBar />);
   expect(screen.getByText('Uploaded Work')).toBeInTheDocument();
 });
+
+test('shows topic dags link', () => {
+  mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+  render(<NavBar />);
+  expect(screen.getByText('Topic DAGs')).toBeInTheDocument();
+});

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -38,6 +38,9 @@ export function NavBar() {
       <Link href="/uploaded-work" style={styles.link}>
         Uploaded Work
       </Link>
+      <Link href="/topic-dags" style={styles.link}>
+        Topic DAGs
+      </Link>
       <Link href="/students" style={styles.link}>
         Students
       </Link>

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -116,3 +116,15 @@ export const tags = sqliteTable('tag', {
   text: text('text').notNull().unique(),
 });
 
+export const topicDags = sqliteTable('topic_dag', {
+  id: text('id').primaryKey().notNull().$defaultFn(() => crypto.randomUUID()),
+  userId: text('userId')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  topics: text('topics', { mode: 'json' }).notNull(),
+  graph: text('graph').notNull(),
+  createdAt: integer('createdAt', { mode: 'timestamp_ms' })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+


### PR DESCRIPTION
## Summary
- allow saving generated topic DAGs with `/api/topic-dags`
- store DAGs per-user in new `topic_dag` table
- show saved graphs on new Topic DAGs page
- add list component with stories and tests
- link Topic DAGs from navigation
- document new feature

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: no such table: uploaded_work_index)*
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686c583c5548832bac7b443819d770ba