### PR TITLE
Show similar tags for uploads

### DIFF
--- a/app/src/app/api/upload-work/route.ts
+++ b/app/src/app/api/upload-work/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/db';
 import { uploadedWork, teacherStudents } from '@/db/schema';
-import { upsertWorkEmbeddings } from '@/db/embeddings';
+import { upsertWorkEmbeddings, tagsForWork } from '@/db/embeddings';
 import crypto from 'node:crypto';
 import { eq, and } from 'drizzle-orm';
 import { getServerSession } from 'next-auth';
@@ -114,5 +114,6 @@ export async function GET() {
     .select()
     .from(uploadedWork)
     .where(eq(uploadedWork.userId, userId));
-  return NextResponse.json({ works });
+  const results = works.map((w) => ({ ...w, tags: tagsForWork(w.id, 3) }));
+  return NextResponse.json({ works: results });
 }

--- a/app/src/components/UploadedWorkList.tsx
+++ b/app/src/components/UploadedWorkList.tsx
@@ -8,6 +8,7 @@ interface Work {
   summary: string | null
   dateUploaded: string
   dateCompleted: string | null
+  tags?: { id: string; text: string }[]
 }
 
 export function UploadedWorkList() {
@@ -36,6 +37,7 @@ export function UploadedWorkList() {
         summary: 'Processing...',
         dateUploaded: new Date().toISOString(),
         dateCompleted: null,
+        tags: [],
       },
       ...prev,
     ])
@@ -63,6 +65,11 @@ export function UploadedWorkList() {
           <li key={w.id} style={{ marginBottom: '1rem' }}>
             <strong>{new Date(w.dateCompleted || w.dateUploaded).toDateString()}</strong>
             <SummaryWithMath text={w.summary ?? ''} />
+            {w.tags && w.tags.length > 0 && (
+              <div>
+                Tags: {w.tags.map((t) => t.text).join(', ')}
+              </div>
+            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- find nearest tags to uploaded work via embeddings
- show tags for each upload in UI
- include tags in GET response
- test API returns tags

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve imports in some test files)*
- `pnpm build` *(fails: no such table: uploaded_work_index)*
- `pnpm typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686c5fbf20c8832baab18841023702d7