### PR TITLE
Add tag recommendations for uploaded work

### DIFF
--- a/app/src/components/UploadedWorkList.test.tsx
+++ b/app/src/components/UploadedWorkList.test.tsx
@@ -6,7 +6,13 @@ vi.stubGlobal('fetch', vi.fn())
 
 const mockFetch = fetch as unknown as Mock
 
-interface Work { id: string; summary: string; dateUploaded: string; dateCompleted: string | null }
+interface Work {
+  id: string
+  summary: string
+  dateUploaded: string
+  dateCompleted: string | null
+  tags: string[]
+}
 
 function mockGet(works: Work[]) {
   mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ works }) })
@@ -20,11 +26,20 @@ describe('UploadedWorkList', () => {
 
   it('loads works on mount', async () => {
     mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ students: [] }) })
-    mockGet([{ id: '1', summary: 'sum', dateUploaded: new Date().toISOString(), dateCompleted: null }])
+    mockGet([
+      {
+        id: '1',
+        summary: 'sum',
+        dateUploaded: new Date().toISOString(),
+        dateCompleted: null,
+        tags: ['t1'],
+      },
+    ])
     render(<UploadedWorkList />)
     expect(mockFetch).toHaveBeenNthCalledWith(1, '/api/students')
     expect(mockFetch).toHaveBeenNthCalledWith(2, '/api/upload-work')
     expect(await screen.findByText('sum')).toBeInTheDocument()
+    expect(await screen.findByText('Tags: t1')).toBeInTheDocument()
   })
 
 })

--- a/app/src/components/UploadedWorkList.tsx
+++ b/app/src/components/UploadedWorkList.tsx
@@ -8,6 +8,7 @@ interface Work {
   summary: string | null
   dateUploaded: string
   dateCompleted: string | null
+  tags: string[]
 }
 
 export function UploadedWorkList() {
@@ -36,6 +37,7 @@ export function UploadedWorkList() {
         summary: 'Processing...',
         dateUploaded: new Date().toISOString(),
         dateCompleted: null,
+        tags: [],
       },
       ...prev,
     ])
@@ -63,6 +65,9 @@ export function UploadedWorkList() {
           <li key={w.id} style={{ marginBottom: '1rem' }}>
             <strong>{new Date(w.dateCompleted || w.dateUploaded).toDateString()}</strong>
             <SummaryWithMath text={w.summary ?? ''} />
+            {w.tags.length > 0 && (
+              <div>Tags: {w.tags.join(', ')}</div>
+            )}
           </li>
         ))}
       </ul>

--- a/app/tests/e2e/uploadWork.test.ts
+++ b/app/tests/e2e/uploadWork.test.ts
@@ -42,7 +42,8 @@ describe('upload-work API', () => {
 
   it('requires auth for GET', async () => {
     (getServerSession as unknown as Mock).mockResolvedValue(null);
-    const res = await getWorks();
+    const req = new NextRequest(new Request('http://localhost/api/upload-work'));
+    const res = await getWorks(req);
     expect(res.status).toBe(401);
   });
 });


### PR DESCRIPTION
## Summary
- compute closest tags for each uploaded work using embeddings
- show recommended tags in the uploaded work list
- update API route to return top tags
- fix e2e tests and adjust embedding helpers

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686c5fbf20c8832baab18841023702d7