### PR TITLE
Add DAG detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A web application for planning and tracking long term learning goals. Users define topic graphs and upload work samples. The app stores metadata and embeddings to recommend what to study next.
 
-Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**. The navigation bar also links to the **Uploaded Work** page and the **Saved DAGs** page.
+Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**. The navigation bar also links to the **Uploaded Work** page and the **My Curriculums** page.
 
 The home page includes a math skill selector that generates a mermaid DAG of prerequisites using the built-in LLM client.
 
@@ -84,9 +84,9 @@ New uploads appear immediately in the list with a temporary "Processing..." plac
 
 Math expressions wrapped in `$...$`, `$$...$$`, `\(...\)` or `\[...\]` in summaries are rendered with KaTeX.
 
-## Saved DAGs
+## My Curriculums
 
-The **Saved DAGs** page lists every topic graph you've generated and saved from the home page. Each entry shows when it was created and which topics were included.
+The **My Curriculums** page lists every topic graph you've generated and saved from the home page. Each entry shows when it was created and which topics were included. Click an entry to view the full graph.
 
 ## Tag Generation
 

--- a/app/src/app/api/topic-dags/[id]/route.ts
+++ b/app/src/app/api/topic-dags/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+import { db } from '@/db'
+import { topicDags } from '@/db/schema'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/authOptions'
+import { eq, and } from 'drizzle-orm'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function GET(_req: Request, context: any) {
+  const { params } = context as { params: { id: string } }
+  const session = await getServerSession(authOptions)
+  const userId = (session?.user as { id?: string } | undefined)?.id
+  if (!userId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+  const [row] = await db
+    .select()
+    .from(topicDags)
+    .where(and(eq(topicDags.userId, userId), eq(topicDags.id, params.id)))
+  if (!row) {
+    return NextResponse.json({ error: 'not found' }, { status: 404 })
+  }
+  return NextResponse.json({ dag: row })
+}

--- a/app/src/app/topic-dags/[id]/page.tsx
+++ b/app/src/app/topic-dags/[id]/page.tsx
@@ -1,0 +1,40 @@
+import { db } from '@/db'
+import { topicDags } from '@/db/schema'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/authOptions'
+import { eq, and } from 'drizzle-orm'
+import { TopicDAGView } from '@/components/TopicDAGView'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default async function DagDetailPage({ params }: any) {
+  const session = await getServerSession(authOptions)
+  const userId = (session?.user as { id?: string } | undefined)?.id
+  if (!userId) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <h1>My Curriculums</h1>
+        <p>Please sign in to view this curriculum.</p>
+      </div>
+    )
+  }
+  const [dag] = await db
+    .select()
+    .from(topicDags)
+    .where(and(eq(topicDags.userId, userId), eq(topicDags.id, params.id)))
+  if (!dag) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <h1>My Curriculums</h1>
+        <p>Curriculum not found.</p>
+      </div>
+    )
+  }
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>My Curriculums</h1>
+      <strong>{new Date(dag.createdAt).toLocaleString()}</strong>
+      <div>{JSON.parse(dag.topics).join(', ')}</div>
+      <TopicDAGView graph={dag.graph} />
+    </div>
+  )
+}

--- a/app/src/app/topic-dags/page.tsx
+++ b/app/src/app/topic-dags/page.tsx
@@ -8,14 +8,14 @@ export default async function TopicDAGsPage() {
   if (!userId) {
     return (
       <div style={{ padding: '2rem' }}>
-        <h1>Saved DAGs</h1>
+        <h1>My Curriculums</h1>
         <p>Please sign in to view your DAGs.</p>
       </div>
     )
   }
   return (
     <div style={{ padding: '2rem' }}>
-      <h1>Saved DAGs</h1>
+      <h1>My Curriculums</h1>
       <TopicDAGList />
     </div>
   )

--- a/app/src/components/NavBar.test.tsx
+++ b/app/src/components/NavBar.test.tsx
@@ -34,5 +34,5 @@ test('shows uploaded work link', () => {
 test('shows saved dags link', () => {
   mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
   render(<NavBar />);
-  expect(screen.getByText('Saved DAGs')).toBeInTheDocument();
+  expect(screen.getByText('My Curriculums')).toBeInTheDocument();
 });

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -39,7 +39,7 @@ export function NavBar() {
         Uploaded Work
       </Link>
       <Link href="/topic-dags" style={styles.link}>
-        Saved DAGs
+        My Curriculums
       </Link>
       <Link href="/students" style={styles.link}>
         Students

--- a/app/src/components/TopicDAGList.test.tsx
+++ b/app/src/components/TopicDAGList.test.tsx
@@ -19,5 +19,7 @@ test('loads DAGs on mount', async () => {
   mockGet([{ id: '1', topics: JSON.stringify(['A', 'B']), graph: 'g', createdAt: new Date().toISOString() }])
   render(<TopicDAGList />)
   expect(mockFetch).toHaveBeenCalledWith('/api/topic-dags')
-  expect(await screen.findByText('A, B')).toBeInTheDocument()
+  const link = await screen.findByRole('link')
+  expect(link).toHaveAttribute('href', '/topic-dags/1')
+  expect(link).toHaveTextContent('A, B')
 })

--- a/app/src/components/TopicDAGList.tsx
+++ b/app/src/components/TopicDAGList.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
+import Link from 'next/link'
 
 interface Dag {
   id: string
@@ -27,8 +28,13 @@ export function TopicDAGList() {
     <ul>
       {dags.map((d) => (
         <li key={d.id} style={{ marginBottom: '1rem' }}>
-          <strong>{new Date(d.createdAt).toLocaleString()}</strong>
-          <div>{JSON.parse(d.topics).join(', ')}</div>
+          <Link
+            href={`/topic-dags/${d.id}`}
+            style={{ textDecoration: 'none', color: 'inherit', display: 'block' }}
+          >
+            <strong>{new Date(d.createdAt).toLocaleString()}</strong>
+            <div>{JSON.parse(d.topics).join(', ')}</div>
+          </Link>
         </li>
       ))}
     </ul>

--- a/app/src/components/TopicDAGView.stories.tsx
+++ b/app/src/components/TopicDAGView.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta } from '@storybook/react'
+import { TopicDAGView } from './TopicDAGView'
+
+const meta: Meta<typeof TopicDAGView> = {
+  title: 'TopicDAGView',
+  component: TopicDAGView,
+}
+export default meta
+
+export const Default = {
+  args: {
+    graph: 'graph TD;A-->B;B-->C;',
+  },
+}

--- a/app/src/components/TopicDAGView.test.tsx
+++ b/app/src/components/TopicDAGView.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react'
+import { TopicDAGView } from './TopicDAGView'
+
+test('renders mermaid graph', () => {
+  render(<TopicDAGView graph="graph TD;A-->B;" />)
+  expect(screen.getByText('A')).toBeInTheDocument()
+})

--- a/app/src/components/TopicDAGView.tsx
+++ b/app/src/components/TopicDAGView.tsx
@@ -1,0 +1,10 @@
+'use client'
+import Mermaid from 'react-mermaid2'
+
+export function TopicDAGView({ graph }: { graph: string }) {
+  return (
+    <div style={{ marginTop: '2rem', textAlign: 'left' as const }}>
+      <Mermaid chart={graph} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- rename Saved DAGs to My Curriculums
- link each DAG row to a detail page
- show saved graph on new curriculum page
- expose API endpoint for single DAG
- add TopicDAGView component with tests and stories

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve import and invalid hook call)*
- `pnpm build` *(fails: no such table: uploaded_work_index)*
- `pnpm typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686c61474fa4832bb5851986deba8cd7