### PR TITLE
Add curriculum view to saved DAGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A web application for planning and tracking long term learning goals. Users define topic graphs and upload work samples. The app stores metadata and embeddings to recommend what to study next.
 
-Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**. The navigation bar also links to the **Uploaded Work** page and the **Saved DAGs** page.
+Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**. The navigation bar also links to the **Uploaded Work** page and the **My Curriculums** page.
 
 The home page includes a math skill selector that generates a mermaid DAG of prerequisites using the built-in LLM client.
 
@@ -84,9 +84,9 @@ New uploads appear immediately in the list with a temporary "Processing..." plac
 
 Math expressions wrapped in `$...$`, `$$...$$`, `\(...\)` or `\[...\]` in summaries are rendered with KaTeX.
 
-## Saved DAGs
+## My Curriculums
 
-The **Saved DAGs** page lists every topic graph you've generated and saved from the home page. Each entry shows when it was created and which topics were included.
+The **My Curriculums** page lists every topic graph you've generated and saved from the home page. Click a row to view the full graph. Each entry shows when it was created and which topics were included.
 
 ## Tag Generation
 

--- a/app/src/app/topic-dags/page.tsx
+++ b/app/src/app/topic-dags/page.tsx
@@ -8,14 +8,14 @@ export default async function TopicDAGsPage() {
   if (!userId) {
     return (
       <div style={{ padding: '2rem' }}>
-        <h1>Saved DAGs</h1>
+        <h1>My Curriculums</h1>
         <p>Please sign in to view your DAGs.</p>
       </div>
     )
   }
   return (
     <div style={{ padding: '2rem' }}>
-      <h1>Saved DAGs</h1>
+      <h1>My Curriculums</h1>
       <TopicDAGList />
     </div>
   )

--- a/app/src/components/NavBar.test.tsx
+++ b/app/src/components/NavBar.test.tsx
@@ -34,5 +34,5 @@ test('shows uploaded work link', () => {
 test('shows saved dags link', () => {
   mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
   render(<NavBar />);
-  expect(screen.getByText('Saved DAGs')).toBeInTheDocument();
+  expect(screen.getByText('My Curriculums')).toBeInTheDocument();
 });

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -39,7 +39,7 @@ export function NavBar() {
         Uploaded Work
       </Link>
       <Link href="/topic-dags" style={styles.link}>
-        Saved DAGs
+        My Curriculums
       </Link>
       <Link href="/students" style={styles.link}>
         Students

--- a/app/src/components/TopicDAGList.test.tsx
+++ b/app/src/components/TopicDAGList.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { TopicDAGList } from './TopicDAGList'
 import type { Mock } from 'vitest'
+vi.mock('react-mermaid2', () => ({ default: () => <div data-testid="mermaid" /> }))
 
 vi.stubGlobal('fetch', vi.fn())
 const mockFetch = fetch as unknown as Mock
@@ -20,4 +21,13 @@ test('loads DAGs on mount', async () => {
   render(<TopicDAGList />)
   expect(mockFetch).toHaveBeenCalledWith('/api/topic-dags')
   expect(await screen.findByText('A, B')).toBeInTheDocument()
+})
+
+test('shows graph when row clicked', async () => {
+  const dag = { id: '1', topics: JSON.stringify(['A']), graph: 'g', createdAt: new Date().toISOString() }
+  mockGet([dag])
+  render(<TopicDAGList />)
+  const row = await screen.findByText('A')
+  fireEvent.click(row)
+  expect(await screen.findByTestId('mermaid')).toBeInTheDocument()
 })

--- a/app/src/components/TopicDAGList.tsx
+++ b/app/src/components/TopicDAGList.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
+import Mermaid from 'react-mermaid2'
 
 interface Dag {
   id: string
@@ -10,6 +11,7 @@ interface Dag {
 
 export function TopicDAGList() {
   const [dags, setDags] = useState<Dag[]>([])
+  const [expanded, setExpanded] = useState<string | null>(null)
 
   const load = async () => {
     const res = await fetch('/api/topic-dags')
@@ -26,9 +28,20 @@ export function TopicDAGList() {
   return (
     <ul>
       {dags.map((d) => (
-        <li key={d.id} style={{ marginBottom: '1rem' }}>
+        <li
+          key={d.id}
+          style={{ marginBottom: '1rem', cursor: 'pointer' }}
+          onClick={() =>
+            setExpanded((prev) => (prev === d.id ? null : d.id))
+          }
+        >
           <strong>{new Date(d.createdAt).toLocaleString()}</strong>
           <div>{JSON.parse(d.topics).join(', ')}</div>
+          {expanded === d.id && (
+            <div style={{ marginTop: '1rem' }}>
+              <Mermaid chart={d.graph} />
+            </div>
+          )}
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- rename Saved DAGs page to "My Curriculums"
- show the DAG graph when a saved entry is clicked
- update navigation and docs
- add tests for new behaviour

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686c61474fa4832bb5851986deba8cd7