### PR TITLE
Improve math parsing in summaries

### DIFF
--- a/app/src/components/SummaryWithMath.test.tsx
+++ b/app/src/components/SummaryWithMath.test.tsx
@@ -9,4 +9,11 @@ describe('SummaryWithMath', () => {
     )
     expect(container.querySelector('.katex')).toBeInTheDocument()
   })
+
+  it('handles parentheses within math', () => {
+    const { getByText } = render(
+      <SummaryWithMath text="Perimeter \\(a+b+c\\)" />
+    )
+    expect(getByText(/a\+b\+c/)).toBeInTheDocument()
+  })
 })

--- a/app/src/components/SummaryWithMath.tsx
+++ b/app/src/components/SummaryWithMath.tsx
@@ -3,7 +3,7 @@ import { InlineMath, BlockMath } from 'react-katex'
 
 export function SummaryWithMath({ text }: { text: string }) {
   const parts = text.split(
-    /(\$\$[^$]*\$\$|\$[^$]*\$|\\\[[^\]]*\\\]|\\\([^\)]*\\\))/g
+    /(\$\$[\s\S]*?\$\$|\$[^$]*?\$|\\\[[\s\S]*?\\\]|\\\([\s\S]*?\\\))/g
   )
   return (
     <span>


### PR DESCRIPTION
## Summary
- handle nested parentheses in SummaryWithMath
- update SummaryWithMath tests for new regex

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686c6c75fed8832ba8a58a50dcec199e