### PR TITLE
Add colored tags for uploads

### DIFF
--- a/app/src/components/TagPill.stories.tsx
+++ b/app/src/components/TagPill.stories.tsx
@@ -1,0 +1,11 @@
+import type { Meta } from '@storybook/react'
+import { TagPill } from './TagPill'
+
+const meta: Meta<typeof TagPill> = {
+  title: 'TagPill',
+  component: TagPill,
+  args: { text: 'math', color: '#ff0000' },
+}
+export default meta
+
+export const Default = {}

--- a/app/src/components/TagPill.test.tsx
+++ b/app/src/components/TagPill.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react'
+import { TagPill } from './TagPill'
+
+test('renders tag text', () => {
+  render(<TagPill text="t1" color="#123456" />)
+  expect(screen.getByText('t1')).toBeInTheDocument()
+})

--- a/app/src/components/TagPill.tsx
+++ b/app/src/components/TagPill.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+export function TagPill({ text, color }: { text: string; color: string }) {
+  return (
+    <span
+      style={{
+        backgroundColor: color,
+        color: '#fff',
+        padding: '0.1rem 0.4rem',
+        borderRadius: '0.5rem',
+        marginRight: '0.25rem',
+        display: 'inline-block',
+        fontSize: '0.85em',
+      }}
+    >
+      {text}
+    </span>
+  )
+}

--- a/app/src/components/UploadedWorkList.test.tsx
+++ b/app/src/components/UploadedWorkList.test.tsx
@@ -11,7 +11,7 @@ interface Work {
   summary: string
   dateUploaded: string
   dateCompleted: string | null
-  tags: string[]
+  tags: { text: string; color: string }[]
 }
 
 function mockGet(works: Work[]) {
@@ -32,14 +32,14 @@ describe('UploadedWorkList', () => {
         summary: 'sum',
         dateUploaded: new Date().toISOString(),
         dateCompleted: null,
-        tags: ['t1'],
+        tags: [{ text: 't1', color: '#111111' }],
       },
     ])
     render(<UploadedWorkList />)
     expect(mockFetch).toHaveBeenNthCalledWith(1, '/api/students')
     expect(mockFetch).toHaveBeenNthCalledWith(2, '/api/upload-work')
     expect(await screen.findByText('sum')).toBeInTheDocument()
-    expect(await screen.findByText('Tags: t1')).toBeInTheDocument()
+    expect(await screen.findByText('t1')).toBeInTheDocument()
   })
 
 })

--- a/app/src/components/UploadedWorkList.tsx
+++ b/app/src/components/UploadedWorkList.tsx
@@ -2,13 +2,19 @@
 import { SummaryWithMath } from '@/components/SummaryWithMath';
 import { useEffect, useState } from 'react'
 import { UploadForm } from './UploadForm'
+import { TagPill } from './TagPill'
+
+interface Tag {
+  text: string
+  color: string
+}
 
 interface Work {
   id: string
   summary: string | null
   dateUploaded: string
   dateCompleted: string | null
-  tags: string[]
+  tags: Tag[]
 }
 
 export function UploadedWorkList() {
@@ -66,7 +72,12 @@ export function UploadedWorkList() {
             <strong>{new Date(w.dateCompleted || w.dateUploaded).toDateString()}</strong>
             <SummaryWithMath text={w.summary ?? ''} />
             {w.tags.length > 0 && (
-              <div>Tags: {w.tags.join(', ')}</div>
+              <div>
+                Tags:{' '}
+                {w.tags.map((t) => (
+                  <TagPill key={t.text} text={t.text} color={t.color} />
+                ))}
+              </div>
             )}
           </li>
         ))}


### PR DESCRIPTION
## Summary
- color code tags under uploaded work
- show tags as pills in UploadedWorkList
- include tag vectors in `/api/upload-work` response
- add TagPill component with tests and story
- update UploadedWorkList tests
- expose helper to fetch tag vectors

## Testing
- `pnpm lint`
- `pnpm panda`
- `pnpm test`
- `pnpm build`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686c6eb50084832bb29df185adabbad8