### PR TITLE
Improve tag pill visuals

### DIFF
--- a/app/src/app/api/upload-work/route.ts
+++ b/app/src/app/api/upload-work/route.ts
@@ -5,6 +5,7 @@ import {
   upsertWorkEmbeddings,
   searchTagsForWork,
   getTagVector,
+  getTagVectorRange,
 } from '@/db/embeddings';
 import crypto from 'node:crypto';
 import { eq, and } from 'drizzle-orm';
@@ -132,5 +133,6 @@ export async function GET(req: NextRequest) {
       .filter((t): t is { text: string; vector: number[] } => Boolean(t));
     return { ...w, tags };
   });
-  return NextResponse.json({ works: workWithTags });
+  const range = getTagVectorRange();
+  return NextResponse.json({ works: workWithTags, range });
 }

--- a/app/src/components/TagPill.stories.tsx
+++ b/app/src/components/TagPill.stories.tsx
@@ -11,5 +11,6 @@ export const Default = {
   args: {
     text: 'example',
     vector: [0.1, 0.2, 0.3],
+    range: { min: [-1, -1, -1], max: [1, 1, 1] },
   },
 }

--- a/app/src/components/TagPill.test.tsx
+++ b/app/src/components/TagPill.test.tsx
@@ -3,7 +3,13 @@ import { TagPill } from './TagPill'
 
 describe('TagPill', () => {
   it('renders text', () => {
-    render(<TagPill text="math" vector={[0.1, 0.2, 0.3]} />)
+    render(
+      <TagPill
+        text="math"
+        vector={[0.1, 0.2, 0.3]}
+        range={{ min: [-1, -1, -1], max: [1, 1, 1] }}
+      />
+    )
     expect(screen.getByText('math')).toBeInTheDocument()
   })
 })

--- a/app/src/components/TagPill.tsx
+++ b/app/src/components/TagPill.tsx
@@ -4,18 +4,21 @@ import { css } from '@/styled-system/css'
 export type TagPillProps = {
   text: string
   vector: number[]
+  range?: { min: number[]; max: number[] }
 }
 
-function vectorToColor(v: number[]): string {
+function vectorToColor(v: number[], range?: { min: number[]; max: number[] }): string {
   if (v.length < 3) return '#999'
-  const hue = ((v[0] + 1) / 2) * 360
-  const sat = 50 + ((v[1] + 1) / 2) * 50
-  const light = 40 + ((v[2] + 1) / 2) * 20
+  const min = range?.min ?? [-1, -1, -1]
+  const max = range?.max ?? [1, 1, 1]
+  const hue = ((v[0] - min[0]) / (max[0] - min[0])) * 360
+  const sat = 50 + ((v[1] - min[1]) / (max[1] - min[1])) * 50
+  const light = 40 + ((v[2] - min[2]) / (max[2] - min[2])) * 20
   return `hsl(${Math.floor(hue) % 360}, ${Math.floor(sat)}%, ${Math.floor(light)}%)`
 }
 
-export function TagPill({ text, vector }: TagPillProps) {
-  const color = vectorToColor(vector)
+export function TagPill({ text, vector, range }: TagPillProps) {
+  const color = vectorToColor(vector, range)
   return (
     <span
       className={css({
@@ -26,6 +29,7 @@ export function TagPill({ text, vector }: TagPillProps) {
         color: 'white',
         fontSize: 'sm',
         marginRight: '1',
+        marginBottom: '1',
       })}
       style={{ backgroundColor: color }}
     >

--- a/app/src/components/UploadedWorkList.test.tsx
+++ b/app/src/components/UploadedWorkList.test.tsx
@@ -20,7 +20,10 @@ interface Work {
 }
 
 function mockGet(works: Work[]) {
-  mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ works }) })
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ works, range: { min: [-1, -1, -1], max: [1, 1, 1] } }),
+  })
 }
 
 

--- a/app/src/components/UploadedWorkList.tsx
+++ b/app/src/components/UploadedWorkList.tsx
@@ -17,16 +17,23 @@ interface Work {
   tags: Tag[]
 }
 
+interface Range {
+  min: number[]
+  max: number[]
+}
+
 export function UploadedWorkList() {
   const [works, setWorks] = useState<Work[]>([])
+  const [range, setRange] = useState<Range | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const loadWorks = async () => {
     try {
       const res = await fetch('/api/upload-work')
       if (!res.ok) throw new Error('load error')
-      const data = (await res.json()) as { works: Work[] }
+      const data = (await res.json()) as { works: Work[]; range: Range }
       setWorks(data.works)
+      setRange(data.range)
     } catch {
       setError('Failed to load uploads')
     }
@@ -74,7 +81,12 @@ export function UploadedWorkList() {
             {w.tags.length > 0 && (
               <div>
                 {w.tags.map((t) => (
-                  <TagPill key={t.text} text={t.text} vector={t.vector} />
+                  <TagPill
+                    key={t.text}
+                    text={t.text}
+                    vector={t.vector}
+                    range={range || undefined}
+                  />
                 ))}
               </div>
             )}


### PR DESCRIPTION
## Summary
- normalize tag color range via DB stats
- include vector range when fetching uploaded work
- render TagPill with margins and normalized colors
- update tests and stories for new props

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686c72f19584832b85ddcd1bc8a3aebd