### PR TITLE
Convert nav and auth components to server

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default async function RootLayout({
       <body>
         <QueryProvider>
           <AuthProvider session={session}>
-            <NavBar />
+            <NavBar session={session} />
             {children}
           </AuthProvider>
         </QueryProvider>

--- a/app/src/components/AuthProvider.tsx
+++ b/app/src/components/AuthProvider.tsx
@@ -1,8 +1,12 @@
-'use client'
+import { SessionProvider } from 'next-auth/react'
+import type { Session } from 'next-auth'
 
-import { SessionProvider } from 'next-auth/react';
-import type { Session } from 'next-auth';
-
-export default function AuthProvider({ children, session }: { children: React.ReactNode; session?: Session | null }) {
-  return <SessionProvider session={session}>{children}</SessionProvider>;
+export default function AuthProvider({
+  children,
+  session,
+}: {
+  children: React.ReactNode
+  session?: Session | null
+}) {
+  return <SessionProvider session={session}>{children}</SessionProvider>
 }

--- a/app/src/components/NavBar.stories.tsx
+++ b/app/src/components/NavBar.stories.tsx
@@ -1,29 +1,22 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { NavBar } from './NavBar';
-import { SessionProvider } from 'next-auth/react';
+import type { Meta, StoryObj } from '@storybook/react'
+import { NavBar } from './NavBar'
 
 const meta: Meta<typeof NavBar> = {
   component: NavBar,
-};
-export default meta;
+}
+export default meta
 
-type Story = StoryObj<typeof NavBar>;
+type Story = StoryObj<typeof NavBar>
 
 export const LoggedOut: Story = {
-  render: () => (
-    <SessionProvider>
-      <NavBar />
-    </SessionProvider>
-  ),
-};
+  args: { session: null },
+}
 
 export const LoggedIn: Story = {
-  render: () => (
-    <SessionProvider session={{
+  args: {
+    session: {
       user: { name: 'Alice', email: 'alice@example.com' },
       expires: '1',
-    }}>
-      <NavBar />
-    </SessionProvider>
-  ),
-};
+    } as any,
+  },
+}

--- a/app/src/components/NavBar.test.tsx
+++ b/app/src/components/NavBar.test.tsx
@@ -1,38 +1,28 @@
-import { render, screen } from '@testing-library/react';
-import { NavBar } from './NavBar';
-import { useSession } from 'next-auth/react';
-import type { Mock } from 'vitest';
+import { render, screen } from '@testing-library/react'
+import { NavBar } from './NavBar'
+import type { Session } from 'next-auth'
 
-vi.mock('next-auth/react', async () => {
-  const actual = (await vi.importActual<typeof import('next-auth/react')>('next-auth/react'));
-  return {
-    ...actual,
-    useSession: vi.fn(),
-    signOut: vi.fn(),
-  };
-});
-const mockedUseSession = useSession as unknown as Mock;
+const session: Session = {
+  user: { name: 'a', email: 'a@example.com' },
+  expires: '1',
+}
 
 test('shows sign in link when unauthenticated', () => {
-  mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
-  render(<NavBar />);
-  expect(screen.getByText('Sign in')).toBeInTheDocument();
-});
+  render(<NavBar session={null} />)
+  expect(screen.getByText('Sign in')).toBeInTheDocument()
+})
 
 test('shows sign out when authenticated', () => {
-  mockedUseSession.mockReturnValue({ data: { user: { name: 'a' }, expires: '1' }, status: 'authenticated' });
-  render(<NavBar />);
-  expect(screen.getByText('Sign out')).toBeInTheDocument();
-});
+  render(<NavBar session={session} />)
+  expect(screen.getByText('Sign out')).toBeInTheDocument()
+})
 
 test('shows uploaded work link', () => {
-  mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
-  render(<NavBar />);
-  expect(screen.getByText('Uploaded Work')).toBeInTheDocument();
-});
+  render(<NavBar session={null} />)
+  expect(screen.getByText('Uploaded Work')).toBeInTheDocument()
+})
 
 test('shows saved dags link', () => {
-  mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
-  render(<NavBar />);
-  expect(screen.getByText('My Curriculums')).toBeInTheDocument();
-});
+  render(<NavBar session={null} />)
+  expect(screen.getByText('My Curriculums')).toBeInTheDocument()
+})

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -1,7 +1,5 @@
-'use client'
-
-import Link from 'next/link';
-import { useSession, signOut } from 'next-auth/react';
+import Link from 'next/link'
+import type { Session } from 'next-auth'
 const styles = {
   bar: {
     display: 'flex',
@@ -28,8 +26,7 @@ const styles = {
   },
 };
 
-export function NavBar() {
-  const { data: session } = useSession();
+export function NavBar({ session }: { session: Session | null }) {
   return (
     <nav style={styles.bar}>
       <Link href="/" style={styles.link}>
@@ -46,9 +43,11 @@ export function NavBar() {
       </Link>
       <div style={styles.spacer} />
       {session ? (
-        <button style={styles.button} onClick={() => signOut()}>
-          Sign out
-        </button>
+        <form action="/api/auth/signout" method="post">
+          <button type="submit" style={styles.button}>
+            Sign out
+          </button>
+        </form>
       ) : (
         <Link href="/login" style={styles.link}>
           Sign in


### PR DESCRIPTION
## Summary
- convert AuthProvider and NavBar to server components
- adjust layout to pass session into NavBar
- update NavBar stories and tests for new API

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686c73cb3360832b80bacb8b8583eb69