### PR TITLE
Fix Panda CSS import and route tag filtering

### DIFF
--- a/app/src/app/api/upload-work/route.ts
+++ b/app/src/app/api/upload-work/route.ts
@@ -148,7 +148,9 @@ export async function GET(req: NextRequest) {
     });
   }
   if (tag) {
-    workWithTags = workWithTags.filter((w) => w.tags.includes(tag));
+    workWithTags = workWithTags.filter((w) =>
+      w.tags.some((t) => t.text === tag)
+    );
   }
 
   const groups: Record<string, typeof workWithTags> = {};
@@ -177,7 +179,7 @@ export async function GET(req: NextRequest) {
           push('untagged', w);
         }
         for (const t of w.tags) {
-          push(t, w);
+          push(t.text, w);
         }
       }
       break;

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import "../styles/index.css";
+import "@/styled-system/styles.css";
 import "katex/dist/katex.min.css";
 import AuthProvider from "@/components/AuthProvider";
 import QueryProvider from "@/components/QueryProvider";


### PR DESCRIPTION
## Summary
- ensure Panda CSS output loads by importing `styles.css`
- correct tag filtering and grouping in uploaded work API

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686c7688e618832babe98db9fb08ec03