### PR TITLE
Convert simple components to server

### DIFF
--- a/app/src/app/api/upload-work/route.ts
+++ b/app/src/app/api/upload-work/route.ts
@@ -148,7 +148,9 @@ export async function GET(req: NextRequest) {
     });
   }
   if (tag) {
-    workWithTags = workWithTags.filter((w) => w.tags.includes(tag));
+    workWithTags = workWithTags.filter((w) =>
+      w.tags.some((t) => t.text === tag)
+    );
   }
 
   const groups: Record<string, typeof workWithTags> = {};
@@ -177,7 +179,7 @@ export async function GET(req: NextRequest) {
           push('untagged', w);
         }
         for (const t of w.tags) {
-          push(t, w);
+          push(t.text, w);
         }
       }
       break;

--- a/app/src/components/SummaryWithMath.tsx
+++ b/app/src/components/SummaryWithMath.tsx
@@ -1,4 +1,4 @@
-"use client"
+
 import { InlineMath, BlockMath } from 'react-katex'
 
 export function SummaryWithMath({ text }: { text: string }) {

--- a/app/src/components/TagPill.tsx
+++ b/app/src/components/TagPill.tsx
@@ -1,4 +1,3 @@
-'use client'
 import { css } from '@/styled-system/css'
 
 export type TagPillProps = {


### PR DESCRIPTION
## Summary
- fix type errors in uploaded work API
- convert TagPill and SummaryWithMath to server components

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686c778301b0832b8e10224268c95eec