### PR TITLE
Refactor database init helpers

### DIFF
--- a/app/scripts/fetch-tags-for-embeddings.ts
+++ b/app/scripts/fetch-tags-for-embeddings.ts
@@ -2,11 +2,13 @@ import { config } from 'dotenv';
 config({ path: '.env.local' });
 
 import crypto from 'node:crypto';
-import { sqlite } from '../src/db';
+import { getSqlite } from '../src/db';
 import { upsertTagEmbeddings } from '../src/db/embeddings';
 import OpenAI from 'openai';
 import { LLMClient } from '../src/llm/client';
 import { z } from 'zod';
+
+const sqlite = getSqlite();
 
 async function main() {
   const summaries = sqlite

--- a/app/src/app/api/students/[id]/route.ts
+++ b/app/src/app/api/students/[id]/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { db } from '@/db'
+import { getDb } from '@/db'
 import { students, teacherStudents, users } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/authOptions'
 import { studentFieldsSchema } from '@/forms/student'
+
+const db = getDb()
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function PUT(req: NextRequest, context: any) {

--- a/app/src/app/api/students/route.ts
+++ b/app/src/app/api/students/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { db } from '@/db'
+import { getDb } from '@/db'
 import { students, teacherStudents, users } from '@/db/schema'
 import { eq } from 'drizzle-orm'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/authOptions'
 import { studentFieldsSchema } from '@/forms/student'
+
+const db = getDb()
 
 export async function GET() {
   const session = await getServerSession(authOptions)

--- a/app/src/app/api/topic-dags/route.ts
+++ b/app/src/app/api/topic-dags/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { db } from '@/db';
+import { getDb } from '@/db';
 import { topicDags } from '@/db/schema';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/authOptions';
 import { z } from 'zod';
 import { eq } from 'drizzle-orm';
+
+const db = getDb();
 
 const postSchema = z.object({ topics: z.array(z.string()), graph: z.string() });
 

--- a/app/src/app/api/upload-work/route.ts
+++ b/app/src/app/api/upload-work/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { db, sqlite } from '@/db';
+import { getDb, getSqlite } from '@/db';
+
+const db = getDb();
+const sqlite = getSqlite();
 import { uploadedWork, teacherStudents } from '@/db/schema';
 import {
   upsertWorkEmbeddings,
@@ -148,7 +151,9 @@ export async function GET(req: NextRequest) {
     });
   }
   if (tag) {
-    workWithTags = workWithTags.filter((w) => w.tags.includes(tag));
+    workWithTags = workWithTags.filter((w) =>
+      w.tags.some((t) => t.text === tag)
+    );
   }
 
   const groups: Record<string, typeof workWithTags> = {};
@@ -177,7 +182,7 @@ export async function GET(req: NextRequest) {
           push('untagged', w);
         }
         for (const t of w.tags) {
-          push(t, w);
+          push(t.text, w);
         }
       }
       break;

--- a/app/src/authOptions.ts
+++ b/app/src/authOptions.ts
@@ -1,7 +1,9 @@
 import { DrizzleAdapter } from '@auth/drizzle-adapter'
 import type { NextAuthOptions } from 'next-auth'
 import EmailProvider from 'next-auth/providers/email'
-import { db } from '@/db'
+import { getDb } from '@/db'
+
+const db = getDb()
 
 export const authOptions: NextAuthOptions = {
   adapter: DrizzleAdapter(db),

--- a/app/src/db/embeddings.ts
+++ b/app/src/db/embeddings.ts
@@ -1,5 +1,7 @@
-import { sqlite } from './index';
+import { getSqlite } from './index';
 import type { Statement } from 'better-sqlite3';
+
+const sqlite = getSqlite();
 
 function safePrepare(sql: string): Statement<unknown[], unknown> {
   try {

--- a/app/src/db/index.ts
+++ b/app/src/db/index.ts
@@ -1,13 +1,28 @@
 import fs from 'fs';
 import Database from 'better-sqlite3';
-import { drizzle } from 'drizzle-orm/better-sqlite3';
+import type { Database as SqliteDatabase } from 'better-sqlite3';
+import { drizzle, type BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import { load as loadVec } from 'sqlite-vec';
 
-export const sqlite = new Database(process.env.DATABASE_URL || './sqlite.db');
-loadVec(sqlite);
-export const db = drizzle(sqlite);
+let sqlite: SqliteDatabase | null = null;
 
-if (fs.existsSync('./drizzle') && process.env.NODE_ENV !== 'production') {
-  migrate(db, { migrationsFolder: './drizzle' });
+export function getSqlite() {
+  if (!sqlite) {
+    sqlite = new Database(process.env.DATABASE_URL || './sqlite.db');
+    loadVec(sqlite);
+  }
+  return sqlite;
+}
+
+let db: BetterSQLite3Database | null = null;
+
+export function getDb() {
+  if (!db) {
+    db = drizzle(getSqlite());
+    if (fs.existsSync('./drizzle') && process.env.NODE_ENV !== 'production') {
+      migrate(db, { migrationsFolder: './drizzle' });
+    }
+  }
+  return db;
 }


### PR DESCRIPTION
## Summary
- create `getSqlite()` and `getDb()` helpers
- switch existing modules to the new helpers
- update TypeScript types

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed Suites 4)*
- `pnpm build` *(fails: process interrupted)*
- `pnpm typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686c76f2abf4832ba17decfd07f0e041