### PR TITLE
Remove unused Babel config

### DIFF
--- a/app/.babelrc
+++ b/app/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": []
-}


### PR DESCRIPTION
## Summary
- remove `.babelrc` to use Next.js default settings

## Testing
- `pnpm lint`
- `pnpm test` *(fails: failed to resolve styled-system imports)*
- `pnpm build`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686d0b511298832b92ae0bc98962b1ea