### PR TITLE
Fix act warning in MathSkillSelector test

### DIFF
--- a/app/src/components/MathSkillSelector.test.tsx
+++ b/app/src/components/MathSkillSelector.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { Mock } from 'vitest';
 vi.mock('react-mermaid2', () => ({ default: () => <div data-testid="mermaid" /> }));
 import { MathSkillSelector } from './MathSkillSelector';
@@ -16,5 +16,6 @@ test('calls API with selected topics and saves', async () => {
   // wait for graph to render
   await screen.findByTestId('mermaid');
   fireEvent.click(screen.getByText('Save Graph'));
+  await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument());
   expect(mockFetch).toHaveBeenLastCalledWith('/api/topic-dags', expect.objectContaining({ method: 'POST' }));
 });


### PR DESCRIPTION
## Summary
- await save confirmation in MathSkillSelector test to avoid `act` warning

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686d0d4c13e0832b8c8cc721410db818