### PR TITLE
Silence Vitest console output

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -17,5 +17,6 @@ export default defineConfig({
     globals: true,
     setupFiles: './vitest.setup.ts',
     exclude: ['tests/e2e/**'],
+    silent: true,
   },
 });

--- a/app/vitest.e2e.config.ts
+++ b/app/vitest.e2e.config.ts
@@ -15,5 +15,6 @@ export default defineConfig({
     include: ['tests/e2e/**/*.test.ts'],
     environment: 'node',
     globals: true,
+    silent: true,
   },
 });


### PR DESCRIPTION
## Summary
- make Vitest run silently by default
- silence console output in e2e config too

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686d10f24a50832b9c18f6d0b2d2cfe2