### PR TITLE
Implement student curriculum page

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Math expressions wrapped in `$...$`, `$$...$$`, `\(...\)` or `\[...\]` in summar
 
 The **My Curriculums** page lists every topic graph you've generated and saved from the home page. Click a row to view the full graph. Each entry shows when it was created and which topics were included.
 
+## Student Progress
+
+From the **Students** page you can click a student's name to view their progress. If no curriculum has been assigned to that student, select one of your saved topic DAGs. Once selected, the page shows the chosen topics, renders the graph, and lists all uploaded work for that student.
+
 ## Tag Generation
 
 Run `pnpm run fetch-tags-for-embeddings` to generate tags for all uploaded work. The script queries every summary, asks the LLM for the top 100 tags, stores them in the database and embeds each tag using the model specified by the `EMBEDDING_MODEL` environment variable (defaults to `text-embedding-3-small`).

--- a/app/drizzle/0006_student_curriculum.sql
+++ b/app/drizzle/0006_student_curriculum.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `teacher_student_curriculum` (
+  `teacherId` text NOT NULL,
+  `studentId` text NOT NULL,
+  `dagId` text NOT NULL,
+  PRIMARY KEY(`teacherId`, `studentId`),
+  FOREIGN KEY (`teacherId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`studentId`) REFERENCES `student`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`dagId`) REFERENCES `topic_dag`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -37,5 +37,13 @@
       "tag": "0005_salty_wolfsbane",
       "breakpoints": true
     }
+    ,
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1751978302326,
+      "tag": "0006_student_curriculum",
+      "breakpoints": true
+    }
   ]
 }

--- a/app/src/app/api/students/[id]/curriculum/route.ts
+++ b/app/src/app/api/students/[id]/curriculum/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDb } from '@/db'
+import { teacherStudentCurriculums, teacherStudents, topicDags } from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/authOptions'
+import { z } from 'zod'
+
+const db = getDb()
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function GET(_req: NextRequest, context: any) {
+  const { params } = context as { params: { id: string } }
+  const session = await getServerSession(authOptions)
+  const teacherId = (session?.user as { id?: string } | undefined)?.id
+  if (!teacherId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+  const studentId = params.id
+  const link = await db
+    .select()
+    .from(teacherStudents)
+    .where(and(eq(teacherStudents.teacherId, teacherId), eq(teacherStudents.studentId, studentId)))
+  if (link.length === 0) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
+  const rows = await db
+    .select({
+      id: teacherStudentCurriculums.dagId,
+      topics: topicDags.topics,
+      graph: topicDags.graph,
+      createdAt: topicDags.createdAt,
+    })
+    .from(teacherStudentCurriculums)
+    .leftJoin(topicDags, eq(teacherStudentCurriculums.dagId, topicDags.id))
+    .where(
+      and(
+        eq(teacherStudentCurriculums.teacherId, teacherId),
+        eq(teacherStudentCurriculums.studentId, studentId)
+      )
+    )
+  const dag = rows[0] ?? null
+  return NextResponse.json({ dag })
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function PUT(req: NextRequest, context: any) {
+  const { params } = context as { params: { id: string } }
+  const session = await getServerSession(authOptions)
+  const teacherId = (session?.user as { id?: string } | undefined)?.id
+  if (!teacherId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+  const studentId = params.id
+  const link = await db
+    .select()
+    .from(teacherStudents)
+    .where(and(eq(teacherStudents.teacherId, teacherId), eq(teacherStudents.studentId, studentId)))
+  if (link.length === 0) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+  }
+  const body = z.object({ dagId: z.string() }).parse(await req.json())
+  const dagId = body.dagId
+  const [dag] = await db
+    .select()
+    .from(topicDags)
+    .where(and(eq(topicDags.id, dagId), eq(topicDags.userId, teacherId)))
+  if (!dag) {
+    return NextResponse.json({ error: 'invalid dag' }, { status: 400 })
+  }
+  const existing = await db
+    .select()
+    .from(teacherStudentCurriculums)
+    .where(and(eq(teacherStudentCurriculums.teacherId, teacherId), eq(teacherStudentCurriculums.studentId, studentId)))
+  if (existing.length === 0) {
+    await db.insert(teacherStudentCurriculums).values({ teacherId, studentId, dagId })
+  } else {
+    await db
+      .update(teacherStudentCurriculums)
+      .set({ dagId })
+      .where(and(eq(teacherStudentCurriculums.teacherId, teacherId), eq(teacherStudentCurriculums.studentId, studentId)))
+  }
+  return NextResponse.json({ ok: true })
+}

--- a/app/src/app/students/[id]/page.tsx
+++ b/app/src/app/students/[id]/page.tsx
@@ -1,0 +1,106 @@
+import { MermaidChart } from '@/components/MermaidChart'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/authOptions'
+import { getDb } from '@/db'
+import { teacherStudents, teacherStudentCurriculums, topicDags } from '@/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { UploadedWorkList } from '@/components/UploadedWorkList'
+
+
+function CurriculumSelect({
+  studentId,
+  dags,
+}: {
+  studentId: string
+  dags: { id: string; topics: string }[]
+}) {
+  'use client'
+  const handleChange = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    const dagId = formData.get('dagId') as string
+    await fetch(`/api/students/${studentId}/curriculum`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dagId }),
+    })
+    location.reload()
+  }
+  return (
+    <form onSubmit={handleChange} style={{ marginBottom: '1rem' }}>
+      <label>
+        Select curriculum
+        <select name="dagId" defaultValue="">
+          <option value="" disabled>
+            Choose curriculum
+          </option>
+          {dags.map((d) => (
+            <option key={d.id} value={d.id}>
+              {JSON.parse(d.topics).join(', ')}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button type="submit">Save</button>
+    </form>
+  )
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default async function StudentPage({ params }: any) {
+  const session = await getServerSession(authOptions)
+  const teacherId = (session?.user as { id?: string } | undefined)?.id
+  if (!teacherId) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <p>Please sign in to view student.</p>
+      </div>
+    )
+  }
+  const db = getDb()
+  const studentId = params.id
+  const link = await db
+    .select()
+    .from(teacherStudents)
+    .where(and(eq(teacherStudents.teacherId, teacherId), eq(teacherStudents.studentId, studentId)))
+  if (link.length === 0) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <p>Student not found.</p>
+      </div>
+    )
+  }
+  const [mapping] = await db
+    .select({
+      dagId: teacherStudentCurriculums.dagId,
+      topics: topicDags.topics,
+      graph: topicDags.graph,
+    })
+    .from(teacherStudentCurriculums)
+    .leftJoin(topicDags, eq(teacherStudentCurriculums.dagId, topicDags.id))
+    .where(
+      and(
+        eq(teacherStudentCurriculums.teacherId, teacherId),
+        eq(teacherStudentCurriculums.studentId, studentId)
+      )
+    )
+  const dags = await db
+    .select({ id: topicDags.id, topics: topicDags.topics })
+    .from(topicDags)
+    .where(eq(topicDags.userId, teacherId))
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Student Curriculum</h1>
+      {mapping ? (
+        <div style={{ marginBottom: '1rem' }}>
+          <h3>Selected Topics: {JSON.parse(mapping.topics || '[]').join(', ')}</h3>
+          <MermaidChart chart={mapping.graph || ''} />
+        </div>
+      ) : (
+        <CurriculumSelect studentId={studentId} dags={dags} />
+      )}
+      <h2>Uploaded Work</h2>
+      <UploadedWorkList studentId={studentId} />
+    </div>
+  )
+}

--- a/app/src/components/MermaidChart.stories.tsx
+++ b/app/src/components/MermaidChart.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { MermaidChart } from './MermaidChart'
+
+const meta: Meta<typeof MermaidChart> = {
+  component: MermaidChart,
+  args: {
+    chart: 'graph TD; A-->B;'
+  }
+}
+export default meta
+
+type Story = StoryObj<typeof MermaidChart>
+
+export const Default: Story = {}

--- a/app/src/components/MermaidChart.test.tsx
+++ b/app/src/components/MermaidChart.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react'
+import { MermaidChart } from './MermaidChart'
+
+vi.mock('react-mermaid2', () => ({ default: ({ chart }: { chart: string }) => <div data-testid="mermaid">{chart}</div> }))
+
+test('renders chart', () => {
+  render(<MermaidChart chart="graph TD;A-->B;" />)
+  expect(screen.getByTestId('mermaid')).toHaveTextContent('graph TD;A-->B;')
+})

--- a/app/src/components/MermaidChart.tsx
+++ b/app/src/components/MermaidChart.tsx
@@ -1,0 +1,6 @@
+'use client'
+import Mermaid from 'react-mermaid2'
+
+export function MermaidChart({ chart }: { chart: string }) {
+  return <Mermaid chart={chart} />
+}

--- a/app/src/components/StudentManager.tsx
+++ b/app/src/components/StudentManager.tsx
@@ -24,6 +24,7 @@ export function StudentManager() {
       <ul>
         {students.map((s) => (
           <li key={s.id}>
+            <a href={`/students/${s.id}`}>{s.name}</a>
             <StudentForm student={s} onSuccess={invalidate} />
           </li>
         ))}

--- a/app/src/components/UploadedWorkList.tsx
+++ b/app/src/components/UploadedWorkList.tsx
@@ -18,11 +18,15 @@ interface Work {
   tags: Tag[]
 }
 
-export function UploadedWorkList() {
+interface Props {
+  studentId?: string
+}
+
+export function UploadedWorkList({ studentId: propStudentId }: Props) {
   const [groups, setGroups] = useState<Record<string, Work[]>>({})
   const [students, setStudents] = useState<{ id: string; name: string }[]>([])
   const [groupBy, setGroupBy] = useState('')
-  const [filterStudent, setFilterStudent] = useState('')
+  const [filterStudent, setFilterStudent] = useState(propStudentId ?? '')
   const [filterDay, setFilterDay] = useState('')
   const [filterTag, setFilterTag] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -39,7 +43,11 @@ export function UploadedWorkList() {
     try {
       const params = new URLSearchParams()
       if (groupBy) params.set('group', groupBy)
-      if (filterStudent) params.set('studentId', filterStudent)
+      if (propStudentId) {
+        params.set('studentId', propStudentId)
+      } else if (filterStudent) {
+        params.set('studentId', filterStudent)
+      }
       if (filterDay) params.set('day', filterDay)
       if (filterTag) params.set('tag', filterTag)
       const url = `/api/upload-work${params.size ? `?${params.toString()}` : ''}`
@@ -59,7 +67,7 @@ export function UploadedWorkList() {
   useEffect(() => {
     loadWorks()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [groupBy, filterStudent, filterDay, filterTag])
+  }, [groupBy, filterStudent, filterDay, filterTag, propStudentId])
 
   const handleStart = () => {
     setError(null)
@@ -90,20 +98,22 @@ export function UploadedWorkList() {
             <option value="tag">Tag</option>
           </select>
         </label>
-        <label>
-          Student
-          <select
-            value={filterStudent}
-            onChange={(e) => setFilterStudent(e.target.value)}
-          >
-            <option value="">All</option>
-            {students.map((s) => (
-              <option key={s.id} value={s.id}>
-                {s.name}
-              </option>
-            ))}
-          </select>
-        </label>
+        {!propStudentId && (
+          <label>
+            Student
+            <select
+              value={filterStudent}
+              onChange={(e) => setFilterStudent(e.target.value)}
+            >
+              <option value="">All</option>
+              {students.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
         <label>
           Day
           <input

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -94,6 +94,24 @@ export const teacherStudents = sqliteTable(
   })
 );
 
+export const teacherStudentCurriculums = sqliteTable(
+  'teacher_student_curriculum',
+  {
+    teacherId: text('teacherId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    studentId: text('studentId')
+      .notNull()
+      .references(() => students.id, { onDelete: 'cascade' }),
+    dagId: text('dagId')
+      .notNull()
+      .references(() => topicDags.id, { onDelete: 'cascade' }),
+  },
+  (t) => ({
+    pk: primaryKey(t.teacherId, t.studentId),
+  })
+);
+
 export const uploadedWork = sqliteTable('uploaded_work', {
   id: text('id').primaryKey().notNull().$defaultFn(() => crypto.randomUUID()),
   userId: text('userId')


### PR DESCRIPTION
## Summary
- create DB table for teacher/student curriculum mapping
- add migration for new table
- expose API to manage a student's curriculum
- link students to their progress page
- support filtering UploadedWorkList by student ID
- add mermaid wrapper component
- display curriculum and work for each student
- document new student progress page

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686d0fa847b4832b886f2d8760550fd6