### PR TITLE
Add student progress page with curriculum selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Math expressions wrapped in `$...$`, `$$...$$`, `\(...\)` or `\[...\]` in summar
 
 The **My Curriculums** page lists every topic graph you've generated and saved from the home page. Click a row to view the full graph. Each entry shows when it was created and which topics were included.
 
+## Student Progress
+
+Click a student's name from the **Students** page to open their progress view. The top of the page shows the selected curriculum along with the topics and rendered DAG. If no curriculum is assigned you can pick one from your saved DAGs. Below the curriculum section all uploaded work for that student is listed using the same interface as the **Uploaded Work** page.
+
 ## Tag Generation
 
 Run `pnpm run fetch-tags-for-embeddings` to generate tags for all uploaded work. The script queries every summary, asks the LLM for the top 100 tags, stores them in the database and embeds each tag using the model specified by the `EMBEDDING_MODEL` environment variable (defaults to `text-embedding-3-small`).

--- a/app/drizzle/0006_student_curriculum.sql
+++ b/app/drizzle/0006_student_curriculum.sql
@@ -1,0 +1,1 @@
+ALTER TABLE teacher_student ADD COLUMN topicDagId text REFERENCES topic_dag(id);--> statement-breakpoint

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1751931141170,
       "tag": "0005_salty_wolfsbane",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1751978193934,
+      "tag": "0006_student_curriculum",
+      "breakpoints": true
     }
   ]
 }

--- a/app/src/app/api/students/[id]/route.ts
+++ b/app/src/app/api/students/[id]/route.ts
@@ -1,12 +1,51 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getDb } from '@/db'
-import { students, teacherStudents, users } from '@/db/schema'
+import { students, teacherStudents, users, topicDags } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/authOptions'
 import { studentFieldsSchema } from '@/forms/student'
+import { z } from 'zod'
 
 const db = getDb()
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function GET(req: NextRequest, context: any) {
+  const { params } = context as { params: { id: string } }
+  const session = await getServerSession(authOptions)
+  const teacherId = (session?.user as { id?: string } | undefined)?.id
+  if (!teacherId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+  const id = params.id
+  const [row] = await db
+    .select({
+      id: students.id,
+      name: students.name,
+      email: students.email,
+      topicDagId: teacherStudents.topicDagId,
+      topics: topicDags.topics,
+      graph: topicDags.graph,
+    })
+    .from(teacherStudents)
+    .innerJoin(students, eq(students.id, teacherStudents.studentId))
+    .leftJoin(topicDags, eq(topicDags.id, teacherStudents.topicDagId))
+    .where(and(eq(teacherStudents.teacherId, teacherId), eq(teacherStudents.studentId, id)))
+
+  if (!row) {
+    return NextResponse.json({ error: 'not found' }, { status: 404 })
+  }
+  return NextResponse.json({
+    student: {
+      id: row.id,
+      name: row.name,
+      email: row.email,
+      topicDagId: row.topicDagId,
+      topics: row.topics ? JSON.parse(row.topics) : null,
+      graph: row.graph ?? null,
+    },
+  })
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function PUT(req: NextRequest, context: any) {
@@ -24,8 +63,11 @@ export async function PUT(req: NextRequest, context: any) {
   if (link.length === 0) {
     return NextResponse.json({ error: 'forbidden' }, { status: 403 })
   }
-  const data = studentFieldsSchema.parse(await req.json())
-  const { name, email } = data
+  const updateSchema = studentFieldsSchema.extend({
+    topicDagId: z.string().nullable().optional(),
+  })
+  const data = updateSchema.parse(await req.json())
+  const { name, email, topicDagId } = data
   let accountUserId: string | null = null
   if (email) {
     const [u] = await db.select().from(users).where(eq(users.email, email))
@@ -35,5 +77,11 @@ export async function PUT(req: NextRequest, context: any) {
     .update(students)
     .set({ name, email: email || null, accountUserId })
     .where(eq(students.id, id))
+  if (topicDagId !== undefined) {
+    await db
+      .update(teacherStudents)
+      .set({ topicDagId: topicDagId || null })
+      .where(and(eq(teacherStudents.teacherId, teacherId), eq(teacherStudents.studentId, id)))
+  }
   return NextResponse.json({ ok: true })
 }

--- a/app/src/app/students/[id]/page.tsx
+++ b/app/src/app/students/[id]/page.tsx
@@ -1,0 +1,26 @@
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/authOptions'
+import { StudentCurriculum } from '@/components/StudentCurriculum'
+import { UploadedWorkList } from '@/components/UploadedWorkList'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default async function StudentProgressPage({ params }: any) {
+  const session = await getServerSession(authOptions)
+  const userId = (session?.user as { id?: string } | undefined)?.id
+  if (!userId) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <h1>Student Progress</h1>
+        <p>Please sign in to view progress.</p>
+      </div>
+    )
+  }
+  const id = params.id as string
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Student Progress</h1>
+      <StudentCurriculum studentId={id} />
+      <UploadedWorkList studentId={id} />
+    </div>
+  )
+}

--- a/app/src/components/StudentCurriculum.stories.tsx
+++ b/app/src/components/StudentCurriculum.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta } from '@storybook/react'
+import { StudentCurriculum } from './StudentCurriculum'
+
+const meta: Meta<typeof StudentCurriculum> = {
+  title: 'StudentCurriculum',
+  component: StudentCurriculum,
+}
+export default meta
+
+export const Default = {
+  args: { studentId: 's1' },
+}

--- a/app/src/components/StudentCurriculum.test.tsx
+++ b/app/src/components/StudentCurriculum.test.tsx
@@ -1,0 +1,42 @@
+vi.mock('react-mermaid2', () => ({ default: () => <div data-testid="mermaid" /> }))
+import { render, screen } from '@testing-library/react'
+import { StudentCurriculum } from './StudentCurriculum'
+import type { Mock } from 'vitest'
+
+vi.stubGlobal('fetch', vi.fn())
+const mockFetch = fetch as unknown as Mock
+
+function mockStudent(topicDagId: string | null) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        student: { topicDagId, topics: topicDagId ? ['A', 'B'] : null, graph: topicDagId ? 'graph' : null },
+      }),
+  })
+}
+
+function mockDags() {
+  mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ dags: [] }) })
+}
+
+describe('StudentCurriculum', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  it('shows selector when no curriculum', async () => {
+    mockStudent(null)
+    mockDags()
+    render(<StudentCurriculum studentId="s1" />)
+    expect(await screen.findByText('Curriculum')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('shows graph when curriculum set', async () => {
+    mockStudent('d1')
+    mockDags()
+    render(<StudentCurriculum studentId="s1" />)
+    expect(await screen.findByText('A, B')).toBeInTheDocument()
+  })
+})

--- a/app/src/components/StudentCurriculum.tsx
+++ b/app/src/components/StudentCurriculum.tsx
@@ -1,0 +1,102 @@
+'use client'
+import { useEffect, useState } from 'react'
+import Mermaid from 'react-mermaid2'
+
+interface Dag {
+  id: string
+  topics: string
+  graph: string
+}
+
+interface StudentData {
+  topicDagId: string | null
+  topics: string[]
+  graph: string | null
+}
+
+export function StudentCurriculum({ studentId }: { studentId: string }) {
+  const [data, setData] = useState<StudentData | null>(null)
+  const [dags, setDags] = useState<Dag[]>([])
+  const [selected, setSelected] = useState('')
+
+  const load = async () => {
+    const res = await fetch(`/api/students/${studentId}`)
+    if (res.ok) {
+      const json = (await res.json()) as {
+        student: {
+          topicDagId: string | null
+          topics: string[] | null
+          graph: string | null
+        }
+      }
+      const s = json.student
+      setData({
+        topicDagId: s.topicDagId,
+        topics: s.topics || [],
+        graph: s.graph,
+      })
+      setSelected(s.topicDagId || '')
+    }
+  }
+
+  const loadDags = async () => {
+    const res = await fetch('/api/topic-dags')
+    if (res.ok) {
+      const json = (await res.json()) as { dags: Dag[] }
+      setDags(json.dags)
+    }
+  }
+
+  const save = async () => {
+    await fetch(`/api/students/${studentId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ topicDagId: selected }),
+    })
+    load()
+  }
+
+  useEffect(() => {
+    load()
+    loadDags()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [studentId])
+
+  if (!data) return null
+
+  if (!data.topicDagId) {
+    return (
+      <div style={{ marginBottom: '1rem' }}>
+        <label>
+          Curriculum
+          <select
+            value={selected}
+            onChange={(e) => setSelected(e.target.value)}
+          >
+            <option value="">Select</option>
+            {dags.map((d) => (
+              <option key={d.id} value={d.id}>
+                {JSON.parse(d.topics).join(', ')}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button onClick={save} disabled={!selected} style={{ marginLeft: '0.5rem' }}>
+          Save
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ marginBottom: '1rem' }}>
+      <h2>Curriculum</h2>
+      <div>{data.topics.join(', ')}</div>
+      {data.graph && (
+        <div style={{ marginTop: '1rem' }}>
+          <Mermaid chart={data.graph} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/src/components/StudentManager.tsx
+++ b/app/src/components/StudentManager.tsx
@@ -24,6 +24,9 @@ export function StudentManager() {
       <ul>
         {students.map((s) => (
           <li key={s.id}>
+            <div style={{ marginBottom: '0.5rem' }}>
+              <a href={`/students/${s.id}`}>{s.name}</a>
+            </div>
             <StudentForm student={s} onSuccess={invalidate} />
           </li>
         ))}

--- a/app/src/components/UploadedWorkList.tsx
+++ b/app/src/components/UploadedWorkList.tsx
@@ -18,14 +18,18 @@ interface Work {
   tags: Tag[]
 }
 
-export function UploadedWorkList() {
+export function UploadedWorkList({ studentId = '' }: { studentId?: string } = {}) {
   const [groups, setGroups] = useState<Record<string, Work[]>>({})
   const [students, setStudents] = useState<{ id: string; name: string }[]>([])
   const [groupBy, setGroupBy] = useState('')
-  const [filterStudent, setFilterStudent] = useState('')
+  const [filterStudent, setFilterStudent] = useState(studentId)
   const [filterDay, setFilterDay] = useState('')
   const [filterTag, setFilterTag] = useState('')
   const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setFilterStudent(studentId)
+  }, [studentId])
 
   const loadStudents = async () => {
     const res = await fetch('/api/students')

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -88,6 +88,7 @@ export const teacherStudents = sqliteTable(
     studentId: text('studentId')
       .notNull()
       .references(() => students.id, { onDelete: 'cascade' }),
+    topicDagId: text('topicDagId').references(() => topicDags.id),
   },
   (ts) => ({
     pk: primaryKey(ts.teacherId, ts.studentId),


### PR DESCRIPTION
## Summary
- support linking a curriculum to a teacher/student pair
- expose API to read and update curriculum for a student
- show link to progress page in StudentManager list
- filter UploadedWorkList by student when passed a studentId
- create StudentCurriculum component with tests and stories
- add `/students/[id]` page displaying selected curriculum and work
- document Student Progress page in README
- add database migration for topicDagId column

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686d0fa847b4832b886f2d8760550fd6