### PR TITLE
fix: await params for dynamic routes

### DIFF
--- a/app/src/app/api/students/[id]/route.ts
+++ b/app/src/app/api/students/[id]/route.ts
@@ -9,15 +9,17 @@ import { z } from 'zod'
 
 const db = getDb()
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function GET(req: NextRequest, context: any) {
-  const { params } = context as { params: { id: string } }
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const params = await context.params
   const session = await getServerSession(authOptions)
   const teacherId = (session?.user as { id?: string } | undefined)?.id
   if (!teacherId) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
   }
-  const id = params.id
+  const { id } = params
   const [row] = await db
     .select({
       id: students.id,
@@ -47,15 +49,17 @@ export async function GET(req: NextRequest, context: any) {
   })
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function PUT(req: NextRequest, context: any) {
-  const { params } = context as { params: { id: string } }
+export async function PUT(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const params = await context.params
   const session = await getServerSession(authOptions)
   const teacherId = (session?.user as { id?: string } | undefined)?.id
   if (!teacherId) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
   }
-  const id = params.id
+  const { id } = params
   const link = await db
     .select()
     .from(teacherStudents)

--- a/app/src/app/profile/[id]/page.tsx
+++ b/app/src/app/profile/[id]/page.tsx
@@ -1,6 +1,10 @@
 import { UserProfile } from '@/components/UserProfile'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function ProfilePage({ params }: any) {
-  return <UserProfile name={`User ${params.id}`} bio="This is the bio." />
+export default async function ProfilePage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  return <UserProfile name={`User ${id}`} bio="This is the bio." />
 }

--- a/app/src/app/students/[id]/page.tsx
+++ b/app/src/app/students/[id]/page.tsx
@@ -3,8 +3,11 @@ import { authOptions } from '@/authOptions'
 import { StudentCurriculum } from '@/components/StudentCurriculum'
 import { UploadedWorkList } from '@/components/UploadedWorkList'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default async function StudentProgressPage({ params }: any) {
+export default async function StudentProgressPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
   const session = await getServerSession(authOptions)
   const userId = (session?.user as { id?: string } | undefined)?.id
   if (!userId) {
@@ -15,7 +18,7 @@ export default async function StudentProgressPage({ params }: any) {
       </div>
     )
   }
-  const id = params.id as string
+  const { id } = await params
   return (
     <div style={{ padding: '2rem' }}>
       <h1>Student Progress</h1>


### PR DESCRIPTION
## Summary
- await params in dynamic pages and API routes

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_686d5e009850832b8f86501ab8065f1f