### PR TITLE
Improve graph generation UX

### DIFF
--- a/app/src/components/MathSkillSelector.test.tsx
+++ b/app/src/components/MathSkillSelector.test.tsx
@@ -9,11 +9,18 @@ const mockFetch = fetch as unknown as Mock;
 const user = userEvent.setup();
 
 test('calls API with selected topics and saves', async () => {
-  mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ graph: 'g' }) });
+  let resolveFetch: (v: { ok: boolean; json: () => Promise<unknown> }) => void;
+  mockFetch.mockImplementationOnce(
+    () => new Promise((r) => {
+      resolveFetch = r;
+    })
+  );
   mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ok: true }) });
   render(<MathSkillSelector />);
   await user.click(screen.getByLabelText('Algebra'));
   await user.click(screen.getByText('Generate Graph'));
+  expect(await screen.findByText('Generating graph...')).toBeInTheDocument();
+  resolveFetch!({ ok: true, json: () => Promise.resolve({ graph: 'g' }) });
   expect(mockFetch).toHaveBeenCalledWith('/api/generate-graph', expect.objectContaining({ method: 'POST' }));
   // wait for graph to render and save button to appear
   await screen.findByTestId('mermaid');
@@ -23,4 +30,14 @@ test('calls API with selected topics and saves', async () => {
   expect(mockFetch).toHaveBeenLastCalledWith('/api/topic-dags', expect.objectContaining({ method: 'POST' }));
   // ensure saved state is applied
   await screen.findByText('Saved');
+});
+
+test('shows error message on failure', async () => {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    json: () => Promise.resolve({ error: 'bad' }),
+  });
+  render(<MathSkillSelector />);
+  await user.click(screen.getByText('Generate Graph'));
+  expect(await screen.findByText('Failed to generate graph: bad. Please try again later.')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- show progress and errors while generating graphs
- test new behaviour in MathSkillSelector

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build` *(fails: Could not locate the bindings file)*

------
https://chatgpt.com/codex/tasks/task_e_686d5f3d31ec832bad12a1f1f68cfa46