### PR TITLE
Show graph generation status and errors

### DIFF
--- a/app/src/components/MathSkillSelector.test.tsx
+++ b/app/src/components/MathSkillSelector.test.tsx
@@ -24,3 +24,31 @@ test('calls API with selected topics and saves', async () => {
   // ensure saved state is applied
   await screen.findByText('Saved');
 });
+
+test('shows loading indicator', async () => {
+  let resolve: (() => void) | undefined;
+  mockFetch.mockImplementationOnce(
+    () =>
+      new Promise((r) => {
+        resolve = () =>
+          r({ ok: true, json: () => Promise.resolve({ graph: 'g' }) });
+      })
+  );
+  render(<MathSkillSelector />);
+  await user.click(screen.getByText('Generate Graph'));
+  expect(screen.getByText('Generating...')).toBeInTheDocument();
+  resolve?.();
+  await screen.findByTestId('mermaid');
+});
+
+test('shows error message when request fails', async () => {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    json: () => Promise.resolve({ error: 'bad' }),
+  });
+  render(<MathSkillSelector />);
+  await user.click(screen.getByText('Generate Graph'));
+  expect(
+    await screen.findByText(/Failed to generate graph: bad/)
+  ).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add loading and error UI to MathSkillSelector
- test handling of loading state and errors when generating graphs

## Testing
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build` *(fails: Could not locate the bindings file)*

------
https://chatgpt.com/codex/tasks/task_e_686d5f3d31ec832bad12a1f1f68cfa46