### PR TITLE
Improve home page styling

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -46,10 +46,12 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.6",
+    "@biomejs/cli-linux-x64": "^2.1.1",
     "@chromatic-com/storybook": "^4.0.1",
     "@eslint/eslintrc": "^3",
     "@pandacss/dev": "^0.54.0",
     "@pandacss/preset-panda": "^0.54.0",
+    "@rollup/rollup-linux-x64-gnu": "^4.44.2",
     "@storybook/addon-a11y": "^9.0.15",
     "@storybook/addon-docs": "^9.0.15",
     "@storybook/addon-vitest": "^9.0.15",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.0.6
         version: 2.0.6
+      '@biomejs/cli-linux-x64':
+        specifier: ^2.1.1
+        version: 2.1.1
       '@chromatic-com/storybook':
         specifier: ^4.0.1
         version: 4.0.1(storybook@9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5))
@@ -87,6 +90,9 @@ importers:
       '@pandacss/preset-panda':
         specifier: ^0.54.0
         version: 0.54.0
+      '@rollup/rollup-linux-x64-gnu':
+        specifier: ^4.44.2
+        version: 4.44.2
       '@storybook/addon-a11y':
         specifier: ^9.0.15
         version: 9.0.15(storybook@9.0.15(@testing-library/dom@10.4.0)(prettier@3.2.5))
@@ -990,6 +996,12 @@ packages:
 
   '@biomejs/cli-linux-x64@2.0.6':
     resolution: {integrity: sha512-geM1MkHTV1Kh2Cs/Xzot9BOF3WBacihw6bkEmxkz4nSga8B9/hWy5BDiOG3gHDGIBa8WxT0nzsJs2f/hPqQIQw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@2.1.1':
+    resolution: {integrity: sha512-3WJ1GKjU7NzZb6RTbwLB59v9cTIlzjbiFLDB0z4376TkDqoNYilJaC37IomCr/aXwuU8QKkrYoHrgpSq5ffJ4Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
@@ -11023,6 +11035,8 @@ snapshots:
   '@biomejs/cli-linux-x64@2.0.6':
     optional: true
 
+  '@biomejs/cli-linux-x64@2.1.1': {}
+
   '@biomejs/cli-win32-arm64@2.0.6':
     optional: true
 
@@ -11959,8 +11973,7 @@ snapshots:
   '@rollup/rollup-linux-s390x-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.44.2':
-    optional: true
+  '@rollup/rollup-linux-x64-gnu@4.44.2': {}
 
   '@rollup/rollup-linux-x64-musl@4.44.2':
     optional: true

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,10 +1,11 @@
-import Link from 'next/link';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/authOptions';
 import { navItems } from '@/navItems';
 import { getDb } from '@/db';
 import { teacherStudents, topicDags } from '@/db/schema';
 import { eq } from 'drizzle-orm';
+import { HomeCard } from '@/components/HomeCard';
+import { css } from '@/styled-system/css';
 
 export default async function HomePage() {
   const session = await getServerSession(authOptions);
@@ -29,23 +30,30 @@ export default async function HomePage() {
     ).length;
   }
 
-  const items = navItems;
-
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Choose Your Own Curriculum</h1>
-      <ul>
-        {items.map((item) => {
+    <div className={css({ px: '8', py: '12', textAlign: 'center' })}>
+      <h1 className={css({ fontSize: '4xl', fontWeight: 'bold', mb: '4' })}>
+        Choose Your Own Curriculum
+      </h1>
+      <p className={css({ mb: '8', color: 'gray.600' })}>
+        Build personalized learning paths for your students.
+      </p>
+      <div
+        className={css({
+          display: 'grid',
+          gap: '4',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+          maxW: '3xl',
+          mx: 'auto',
+        })}
+      >
+        {navItems.map((item) => {
           let text = item.label;
           if (item.key === 'students') text = `${studentCount} students`;
           if (item.key === 'curriculums') text = `${curriculumCount} curriculums`;
-          return (
-            <li key={item.href} style={{ marginBottom: '0.5rem' }}>
-              <Link href={item.href}>{text}</Link>
-            </li>
-          );
+          return <HomeCard key={item.href} href={item.href} label={text} />;
         })}
-      </ul>
+      </div>
     </div>
   );
 }

--- a/app/src/components/HomeCard.stories.tsx
+++ b/app/src/components/HomeCard.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { HomeCard } from './HomeCard';
+
+const meta: Meta<typeof HomeCard> = {
+  component: HomeCard,
+};
+export default meta;
+
+type Story = StoryObj<typeof HomeCard>;
+
+export const Default: Story = {
+  args: { href: '/', label: 'Example' },
+};

--- a/app/src/components/HomeCard.test.tsx
+++ b/app/src/components/HomeCard.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import { HomeCard } from './HomeCard';
+
+test('renders label', () => {
+  render(<HomeCard href="/test" label="Test" />);
+  expect(screen.getByText('Test')).toBeInTheDocument();
+});

--- a/app/src/components/HomeCard.tsx
+++ b/app/src/components/HomeCard.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import { css } from '@/styled-system/css';
+
+export type HomeCardProps = {
+  href: string;
+  label: string;
+};
+
+export function HomeCard({ href, label }: HomeCardProps) {
+  return (
+    <Link
+      href={href}
+      className={css({
+        display: 'block',
+        padding: '4',
+        borderRadius: 'lg',
+        background: 'blue.50',
+        color: 'blue.900',
+        textDecoration: 'none',
+        fontWeight: 'medium',
+        shadow: 'sm',
+        _hover: { background: 'blue.100' },
+      })}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/docs/usage/home_page.md
+++ b/docs/usage/home_page.md
@@ -1,3 +1,7 @@
 # Home Page
 
-The home page includes a math skill selector that generates a Mermaid DAG of prerequisites using the built-in LLM client.
+The home page now features a simple hero section with quick links to common tasks.
+If you are signed in, the links display the number of students and curriculums you
+currently have. Use these links to jump straight to managing students, viewing
+curriculums or uploading work. A math skill selector is also available to
+generate a Mermaid DAG of prerequisites using the built‑in LLM client.


### PR DESCRIPTION
## Summary
- add `HomeCard` component with Panda CSS tokens
- redesign home page to use `HomeCard` links
- document home page update
- install platform-specific biome and rollup binaries

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686d6c49a5ec832bb6207b9a66d309d0