### PR TITLE
Improve home UI with nav cards

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,4 +1,5 @@
-import Link from 'next/link';
+import { css } from "@/styled-system/css";
+import { NavCard } from "@/components/NavCard";
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/authOptions';
 import { navItems } from '@/navItems';
@@ -32,20 +33,28 @@ export default async function HomePage() {
   const items = navItems;
 
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Choose Your Own Curriculum</h1>
-      <ul>
+    <div
+      className={css({
+        maxW: "xl",
+        mx: "auto",
+        py: "8",
+        px: "4",
+        textAlign: "center",
+      })}
+    >
+      <h1 className={css({ fontSize: "3xl", fontWeight: "bold", mb: "6" })}>
+        Choose Your Own Curriculum
+      </h1>
+      <div className={css({ display: "grid", gap: "4", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" })}>
         {items.map((item) => {
-          let text = item.label;
-          if (item.key === 'students') text = `${studentCount} students`;
-          if (item.key === 'curriculums') text = `${curriculumCount} curriculums`;
+          let count: number | undefined;
+          if (item.key === "students") count = studentCount;
+          if (item.key === "curriculums") count = curriculumCount;
           return (
-            <li key={item.href} style={{ marginBottom: '0.5rem' }}>
-              <Link href={item.href}>{text}</Link>
-            </li>
+            <NavCard key={item.href} href={item.href} label={item.label} count={count} />
           );
         })}
-      </ul>
+      </div>
     </div>
   );
 }

--- a/app/src/components/NavCard.stories.tsx
+++ b/app/src/components/NavCard.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta } from "@storybook/react";
+import { NavCard } from "./NavCard";
+
+const meta: Meta<typeof NavCard> = {
+  title: "NavCard",
+  component: NavCard,
+};
+export default meta;
+
+export const Default = {
+  args: { href: "/students", label: "Students", count: 3 },
+};

--- a/app/src/components/NavCard.test.tsx
+++ b/app/src/components/NavCard.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import { NavCard } from "./NavCard";
+
+describe("NavCard", () => {
+  it("renders label and count", () => {
+    render(<NavCard href="/" label="Test" count={5} />);
+    expect(screen.getByText("Test")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+});

--- a/app/src/components/NavCard.tsx
+++ b/app/src/components/NavCard.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { css } from "@/styled-system/css";
+
+export interface NavCardProps {
+  href: string;
+  label: string;
+  count?: number;
+}
+
+export function NavCard({ href, label, count }: NavCardProps) {
+  return (
+    <Link
+      href={href}
+      className={css({
+        display: "block",
+        padding: "4",
+        borderRadius: "lg",
+        bg: { base: "blue.500", _hover: "blue.600" },
+        color: "white",
+        textAlign: "center",
+        textDecoration: "none",
+      })}
+    >
+      <span className={css({ fontSize: "xl", fontWeight: "bold" })}>{label}</span>
+      {count !== undefined && (
+        <span className={css({ display: "block", fontSize: "sm", mt: "1" })}>
+          {count}
+        </span>
+      )}
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- add `NavCard` component with Panda styling
- update the home page to show nav cards
- include storybook story and test for `NavCard`

## Testing
- `pnpm run lint`
- `pnpm run panda`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_686d6c49a5ec832bb6207b9a66d309d0