### PR TITLE
Implement graph schema output

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ A web application for planning and tracking long term learning goals. Users defi
 
 Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**. The navigation bar also links to the **Uploaded Work** page and the **My Curriculums** page.
 
-The home page includes a math skill selector that generates a mermaid DAG of prerequisites using the built-in LLM client.
+The home page includes a math skill selector that generates prerequisite graphs as JSON using the built-in LLM client. The graphs are converted to Mermaid diagrams only when rendered.
 =======
 A web application for planning and tracking long term learning goals. Users define topic graphs and upload work samples. The app stores metadata and embeddings to recommend what to study next.
 
 Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**. The navigation bar links to **Upload Work**, **Curriculums** and **Students**.
 
-The Curriculum Generator moved to `/curriculum-generator`. Start there from the **Curriculums** page to generate a mermaid DAG of prerequisites.
+The Curriculum Generator moved to `/curriculum-generator`. Start there from the **Curriculums** page to generate prerequisite graphs.
 >>>>>>> vze0e8-codex/rename-home-page-to-curriculum-generator
 
 ## Tech Stack

--- a/app/src/app/api/generate-graph/route.ts
+++ b/app/src/app/api/generate-graph/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { LLMClient } from '@/llm/client';
+import { GraphSchema } from '@/graphSchema';
 
 const bodySchema = z.object({ topics: z.array(z.string()) });
 
@@ -14,8 +15,8 @@ export async function POST(req: NextRequest) {
     console.log('OPENAI_API_KEY loaded');
   }
   const client = new LLMClient(apiKey || '');
-  const schema = z.object({ graph: z.string() });
-  const prompt = `Create a mermaid DAG flowing from left to right showing a progression from kindergarten math to these topics: ${topics.join(', ')}. The diagram should be as granular as possible by topic and include prerequisite links.`;
+  const schema = z.object({ graph: GraphSchema });
+  const prompt = `Create a topic dependency graph flowing from left to right starting at kindergarten math and covering these topics: ${topics.join(', ')}. Use granular nodes and include prerequisite links.`;
   const result = await client.chat(prompt, {
     systemPrompt: 'You are an expert math curriculum planner.',
     schema,

--- a/app/src/app/api/students/[id]/route.ts
+++ b/app/src/app/api/students/[id]/route.ts
@@ -44,7 +44,7 @@ export async function GET(
       email: row.email,
       topicDagId: row.topicDagId,
       topics: row.topics ? JSON.parse(row.topics) : null,
-      graph: row.graph ?? null,
+      graph: row.graph ? JSON.parse(row.graph) : null,
     },
   })
 }

--- a/app/src/components/MathSkillSelector.test.tsx
+++ b/app/src/components/MathSkillSelector.test.tsx
@@ -20,7 +20,7 @@ test('calls API with selected topics and saves', async () => {
   await user.click(screen.getByLabelText('Algebra'));
   await user.click(screen.getByText('Generate Graph'));
   expect(await screen.findByText('Generating graph...')).toBeInTheDocument();
-  resolveFetch!({ ok: true, json: () => Promise.resolve({ graph: 'g' }) });
+  resolveFetch!({ ok: true, json: () => Promise.resolve({ graph: { nodes: [{ id: 'a', label: 'A', desc: '', tags: ['t1','t2','t3'] }], edges: [] } }) });
   expect(mockFetch).toHaveBeenCalledWith('/api/generate-graph', expect.objectContaining({ method: 'POST' }));
   // wait for graph to render and save button to appear
   await screen.findByTestId('mermaid');

--- a/app/src/components/MathSkillSelector.tsx
+++ b/app/src/components/MathSkillSelector.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import { css } from '@/styled-system/css';
 import Mermaid from 'react-mermaid2';
+import { Graph } from '@/graphSchema';
+import { graphToMermaid } from '@/graphToMermaid';
 const styles = {
   container: { padding: '2rem' },
   list: { display: 'flex', flexDirection: 'column' as const, alignItems: 'flex-start', gap: '0.25rem' },
@@ -28,7 +30,7 @@ const skills = [
 
 export function MathSkillSelector() {
   const [selected, setSelected] = useState<string[]>([]);
-  const [graph, setGraph] = useState('');
+  const [graph, setGraph] = useState<Graph | null>(null);
   const [saved, setSaved] = useState(false);
   const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
@@ -54,7 +56,7 @@ export function MathSkillSelector() {
         setStatus('error');
         return;
       }
-      const data = (await res.json()) as { graph: string };
+      const data = (await res.json()) as { graph: Graph };
       setGraph(data.graph);
       setSaved(false);
       setStatus('idle');
@@ -75,6 +77,7 @@ export function MathSkillSelector() {
     }
   };
 
+  const mermaid = graph ? graphToMermaid(graph) : '';
   return (
     <div style={styles.container}>
       <div style={styles.list}>
@@ -108,7 +111,7 @@ export function MathSkillSelector() {
       {graph && (
         <div id="graph-container" style={styles.graph}>
           {/* re-mount Mermaid when chart string changes to ensure re-render */}
-            <Mermaid key={graph} chart={graph} />
+            <Mermaid key={mermaid} chart={mermaid} />
           </div>
         )}
     </div>

--- a/app/src/components/StudentCurriculum.test.tsx
+++ b/app/src/components/StudentCurriculum.test.tsx
@@ -11,7 +11,13 @@ function mockStudent(topicDagId: string | null) {
     ok: true,
     json: () =>
       Promise.resolve({
-        student: { topicDagId, topics: topicDagId ? ['A', 'B'] : null, graph: topicDagId ? 'graph' : null },
+        student: {
+          topicDagId,
+          topics: topicDagId ? ['A', 'B'] : null,
+          graph: topicDagId
+            ? { nodes: [{ id: 'a', label: 'A', desc: '', tags: ['t1','t2','t3'] }], edges: [] }
+            : null,
+        },
       }),
   })
 }

--- a/app/src/components/StudentCurriculum.tsx
+++ b/app/src/components/StudentCurriculum.tsx
@@ -1,17 +1,19 @@
 'use client'
 import { useEffect, useState } from 'react'
 import Mermaid from 'react-mermaid2'
+import { Graph } from '@/graphSchema'
+import { graphToMermaid } from '@/graphToMermaid'
 
 interface Dag {
   id: string
   topics: string
-  graph: string
+  graph: Graph
 }
 
 interface StudentData {
   topicDagId: string | null
   topics: string[]
-  graph: string | null
+  graph: Graph | null
 }
 
 export function StudentCurriculum({ studentId }: { studentId: string }) {
@@ -26,7 +28,7 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
         student: {
           topicDagId: string | null
           topics: string[] | null
-          graph: string | null
+          graph: Graph | null
         }
       }
       const s = json.student
@@ -94,7 +96,7 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
       <div>{data.topics.join(', ')}</div>
       {data.graph && (
         <div style={{ marginTop: '1rem' }}>
-          <Mermaid chart={data.graph} />
+          <Mermaid chart={graphToMermaid(data.graph)} />
         </div>
       )}
     </div>

--- a/app/src/components/TopicDAGList.test.tsx
+++ b/app/src/components/TopicDAGList.test.tsx
@@ -6,7 +6,7 @@ vi.mock('react-mermaid2', () => ({ default: () => <div data-testid="mermaid" /> 
 vi.stubGlobal('fetch', vi.fn())
 const mockFetch = fetch as unknown as Mock
 
-interface Dag { id: string; topics: string; graph: string; createdAt: string }
+interface Dag { id: string; topics: string; graph: unknown; createdAt: string }
 
 function mockGet(dags: Dag[]) {
   mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ dags }) })
@@ -17,14 +17,14 @@ beforeEach(() => {
 })
 
 test('loads DAGs on mount', async () => {
-  mockGet([{ id: '1', topics: JSON.stringify(['A', 'B']), graph: 'g', createdAt: new Date().toISOString() }])
+  mockGet([{ id: '1', topics: JSON.stringify(['A', 'B']), graph: { nodes: [{ id: 'a', label: 'A', desc: '', tags: ['t1','t2','t3'] }], edges: [] }, createdAt: new Date().toISOString() }])
   render(<TopicDAGList />)
   expect(mockFetch).toHaveBeenCalledWith('/api/topic-dags')
   expect(await screen.findByText('A, B')).toBeInTheDocument()
 })
 
 test('shows graph when row clicked', async () => {
-  const dag = { id: '1', topics: JSON.stringify(['A']), graph: 'g', createdAt: new Date().toISOString() }
+  const dag = { id: '1', topics: JSON.stringify(['A']), graph: { nodes: [{ id: 'a', label: 'A', desc: '', tags: ['t1','t2','t3'] }], edges: [] }, createdAt: new Date().toISOString() }
   mockGet([dag])
   render(<TopicDAGList />)
   const row = await screen.findByText('A')

--- a/app/src/components/TopicDAGList.tsx
+++ b/app/src/components/TopicDAGList.tsx
@@ -1,11 +1,13 @@
 'use client'
 import { useEffect, useState } from 'react'
 import Mermaid from 'react-mermaid2'
+import { Graph } from '@/graphSchema'
+import { graphToMermaid } from '@/graphToMermaid'
 
 interface Dag {
   id: string
   topics: string
-  graph: string
+  graph: Graph
   createdAt: string
 }
 
@@ -39,7 +41,7 @@ export function TopicDAGList() {
           <div>{JSON.parse(d.topics).join(', ')}</div>
           {expanded === d.id && (
             <div style={{ marginTop: '1rem' }}>
-              <Mermaid chart={d.graph} />
+              <Mermaid chart={graphToMermaid(d.graph)} />
             </div>
           )}
         </li>

--- a/app/src/graphSchema.ts
+++ b/app/src/graphSchema.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+/**
+ * A single concept in the tech-tree.
+ */
+export const NodeSchema = z.object({
+  /** Stable snake_case identifier used for edges & code refs */
+  id: z.string().regex(/^[a-z0-9_]+$/, "id must be lowercase snake_case"),
+  /** Short human-readable title shown in the UI */
+  label: z.string(),
+  /** 1-sentence description (used for tooltips, search, etc.) */
+  desc: z.string(),
+  /** Approximate grade level (“K”, “1”, … “12”, “Undergrad”, etc.) */
+  grade: z.string().optional(),
+  /** Zero or more prerequisite node ids */
+  prereq: z.array(z.string()).optional().default([]),
+  /** 5-7 context-free tags for embeddings */
+  tags: z.array(z.string()).min(3).max(10)
+});
+
+/**
+ * Edge = [parentId, childId]
+ */
+export const EdgeSchema = z.tuple([z.string(), z.string()]);
+
+/**
+ * Full graph payload.
+ */
+export const GraphSchema = z.object({
+  /** Optional version to help with future migrations */
+  version: z.literal("1.0").optional(),
+  nodes: z.array(NodeSchema).min(1),
+  edges: z.array(EdgeSchema)
+});
+
+export type Node = z.infer<typeof NodeSchema>;
+export type Edge = z.infer<typeof EdgeSchema>;
+export type Graph = z.infer<typeof GraphSchema>;

--- a/app/src/graphToMermaid.ts
+++ b/app/src/graphToMermaid.ts
@@ -1,0 +1,13 @@
+import { Graph } from "./graphSchema";
+
+export function graphToMermaid(graph: Graph): string {
+  const lines = ["graph LR"];
+  for (const node of graph.nodes) {
+    const label = node.label.replace(/"/g, '\\"');
+    lines.push(`  ${node.id}["${label}"]`);
+  }
+  for (const [from, to] of graph.edges) {
+    lines.push(`  ${from} --> ${to}`);
+  }
+  return lines.join("\n");
+}

--- a/app/tests/e2e/generateGraph.test.ts
+++ b/app/tests/e2e/generateGraph.test.ts
@@ -5,7 +5,10 @@ import { POST as generateGraph } from '@/app/api/generate-graph/route';
 vi.mock('@/llm/client', () => {
   return {
     LLMClient: vi.fn().mockImplementation(() => ({
-      chat: vi.fn(async () => ({ error: null, response: { graph: 'test-graph' } }))
+      chat: vi.fn(async () => ({
+        error: null,
+        response: { graph: { nodes: [{ id: 'a', label: 'A', desc: '', tags: ['t1', 't2', 't3'] }], edges: [] } }
+      }))
     }))
   };
 });
@@ -20,6 +23,6 @@ describe('generate-graph API', () => {
     const res = await generateGraph(req);
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json.graph).toBe('test-graph');
+    expect(json.graph.nodes[0].id).toBe('a');
   });
 });


### PR DESCRIPTION
## Summary
- switch LLM graph output from Mermaid code to typed JSON schema
- parse graph JSON in API routes and components
- convert graph JSON to Mermaid at render time
- update tests for new graph format
- mention JSON graphs in README

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686d7d6944bc832b89c3e574ac10e2b3