### PR TITLE
Fix merge conflict text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,10 @@
 # Choose Your Own Curriculum
 
-<<<<<<< HEAD
-Choose Your Own Curriculum is a web application for planning and tracking long term learning goals. It lets users define topic graphs, upload work samples and stores embeddings to recommend what to study next.
-||||||| 5f73234
-A web application for planning and tracking long term learning goals. Users define topic graphs and upload work samples. The app stores metadata and embeddings to recommend what to study next.
+Choose Your Own Curriculum is a web application for planning and tracking long term learning goals. Users define topic graphs and upload work samples. The app stores metadata and embeddings to recommend what to study next.
 
-Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**. The navigation bar also links to the **Uploaded Work** page and the **My Curriculums** page.
+Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**. The navigation bar links to **Upload Work** (the Uploaded Work page), **Curriculums** (My Curriculums) and **Students**.
 
-The home page includes a math skill selector that generates prerequisite graphs as JSON using the built-in LLM client. The graphs are converted to Mermaid diagrams only when rendered.
-=======
-A web application for planning and tracking long term learning goals. Users define topic graphs and upload work samples. The app stores metadata and embeddings to recommend what to study next.
-
-Users can authenticate via email. Use the navigation bar's **Sign in** link to open the `/login` page. Once signed in, the link changes to **Sign out**. The navigation bar links to **Upload Work**, **Curriculums** and **Students**.
-
-The Curriculum Generator moved to `/curriculum-generator`. Start there from the **Curriculums** page to generate prerequisite graphs.
->>>>>>> vze0e8-codex/rename-home-page-to-curriculum-generator
+The home page includes a math skill selector that generates prerequisite graphs as JSON using the built-in LLM client. The graphs are converted to Mermaid diagrams only when rendered. The Curriculum Generator moved to `/curriculum-generator`; start there from the **Curriculums** page to generate prerequisite graphs.
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary
- clean up merge conflict markers in README
- clarify navigation links and curriculum generator location

## Testing
- `pnpm run format` *(no files processed)*
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686d861d3e30832bac9462f1b592467b