### PR TITLE
Fix pluralization for dynamic counts

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -6,6 +6,7 @@ import { teacherStudents, topicDags } from '@/db/schema';
 import { eq } from 'drizzle-orm';
 import { HomeCard } from '@/components/HomeCard';
 import { css } from '@/styled-system/css';
+import { pluralize } from '@/lib/pluralize';
 
 export default async function HomePage() {
   const session = await getServerSession(authOptions);
@@ -49,8 +50,12 @@ export default async function HomePage() {
       >
         {navItems.map((item) => {
           let text = item.label;
-          if (item.key === 'students') text = `${studentCount} students`;
-          if (item.key === 'curriculums') text = `${curriculumCount} curriculums`;
+          if (item.key === 'students') {
+            text = pluralize(studentCount, 'student');
+          }
+          if (item.key === 'curriculums') {
+            text = pluralize(curriculumCount, 'curriculum', 'curriculums');
+          }
           return <HomeCard key={item.href} href={item.href} label={text} />;
         })}
       </div>

--- a/app/src/lib/pluralize.ts
+++ b/app/src/lib/pluralize.ts
@@ -1,0 +1,4 @@
+export function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+


### PR DESCRIPTION
## Summary
- add a `pluralize` helper function
- use `pluralize` on the home page to show singular text when counts are `1`

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686d88c9d7e8832ba0493c95eff71144