### PR TITLE
Implement streaming graph generation

### DIFF
--- a/app/src/app/api/generate-graph/route.ts
+++ b/app/src/app/api/generate-graph/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+import OpenAI from 'openai';
 import { LLMClient } from '@/llm/client';
 import { GraphSchema } from '@/graphSchema';
 
@@ -14,9 +15,42 @@ export async function POST(req: NextRequest) {
   } else {
     console.log('OPENAI_API_KEY loaded');
   }
+  const wantsStream = req.headers.get('accept') === 'text/event-stream';
+  const prompt = `Create a topic dependency graph flowing from left to right starting at kindergarten math and covering these topics: ${topics.join(', ')}. Use granular nodes and include prerequisite links.`;
+
+  if (wantsStream) {
+    const openai = new OpenAI({ apiKey: apiKey || '' });
+    const stream = await openai.chat.completions.create({
+      model: 'o4-mini',
+      stream: true,
+      max_tokens: 800,
+      messages: [
+        { role: 'system', content: 'You are an expert math curriculum planner. Respond ONLY with JSON.' },
+        { role: 'user', content: prompt },
+      ],
+    });
+    const encoder = new TextEncoder();
+    const readable = new ReadableStream({
+      async start(controller) {
+        for await (const chunk of stream) {
+          const delta = chunk.choices[0]?.delta?.content;
+          if (delta) {
+            controller.enqueue(encoder.encode(delta));
+          }
+        }
+        controller.close();
+      },
+    });
+    return new NextResponse(readable, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+      },
+    });
+  }
+
   const client = new LLMClient(apiKey || '');
   const schema = z.object({ graph: GraphSchema });
-  const prompt = `Create a topic dependency graph flowing from left to right starting at kindergarten math and covering these topics: ${topics.join(', ')}. Use granular nodes and include prerequisite links.`;
   const result = await client.chat(prompt, {
     systemPrompt: 'You are an expert math curriculum planner.',
     schema,

--- a/app/src/components/MathSkillSelector.test.tsx
+++ b/app/src/components/MathSkillSelector.test.tsx
@@ -11,16 +11,26 @@ const user = userEvent.setup();
 test('calls API with selected topics and saves', async () => {
   let resolveFetch: (v: { ok: boolean; json: () => Promise<unknown> }) => void;
   mockFetch.mockImplementationOnce(
-    () => new Promise((r) => {
-      resolveFetch = r;
-    })
+    () =>
+      new Promise((r) => {
+        resolveFetch = r;
+      })
   );
-  mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ok: true }) });
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ ok: true }),
+    headers: { get: () => null },
+  });
   render(<MathSkillSelector />);
   await user.click(screen.getByLabelText('Algebra'));
   await user.click(screen.getByText('Generate Graph'));
   expect(await screen.findByText('Generating graph...')).toBeInTheDocument();
-  resolveFetch!({ ok: true, json: () => Promise.resolve({ graph: { nodes: [{ id: 'a', label: 'A', desc: '', tags: ['t1','t2','t3'] }], edges: [] } }) });
+  resolveFetch!({
+    ok: true,
+    json: () =>
+      Promise.resolve({ graph: { nodes: [{ id: 'a', label: 'A', desc: '', tags: ['t1', 't2', 't3'] }], edges: [] } }),
+    headers: { get: () => null },
+  });
   expect(mockFetch).toHaveBeenCalledWith('/api/generate-graph', expect.objectContaining({ method: 'POST' }));
   // wait for graph to render and save button to appear
   await screen.findByTestId('mermaid');
@@ -36,6 +46,7 @@ test('shows error message on failure', async () => {
   mockFetch.mockResolvedValueOnce({
     ok: false,
     json: () => Promise.resolve({ error: 'bad' }),
+    headers: { get: () => null },
   });
   render(<MathSkillSelector />);
   await user.click(screen.getByText('Generate Graph'));


### PR DESCRIPTION
## Summary
- stream graph data from the server when `Accept: text/event-stream` header is sent
- update MathSkillSelector to parse streamed JSON and show progress bar
- adjust tests for new fetch headers

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686d87ad9d04832ba347deae7c9b12b4