### PR TITLE
Implement streamed curriculum graphs

### DIFF
--- a/app/src/app/api/generate-graph/route.ts
+++ b/app/src/app/api/generate-graph/route.ts
@@ -17,13 +17,13 @@ export async function POST(req: NextRequest) {
   const client = new LLMClient(apiKey || '');
   const schema = z.object({ graph: GraphSchema });
   const prompt = `Create a topic dependency graph flowing from left to right starting at kindergarten math and covering these topics: ${topics.join(', ')}. Use granular nodes and include prerequisite links.`;
-  const result = await client.chat(prompt, {
+  const stream = await client.streamChat(prompt, {
     systemPrompt: 'You are an expert math curriculum planner.',
     schema,
+    stream: true,
+    params: { model: 'o4-mini', max_tokens: 800 },
   });
-  if (result.error || !result.response) {
-    console.error('LLM chat failed', result.error);
-    return NextResponse.json({ error: result.error?.message || 'error' }, { status: 500 });
-  }
-  return NextResponse.json({ graph: result.response.graph });
+  return new NextResponse(stream, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
 }

--- a/docs/usage/home_page.md
+++ b/docs/usage/home_page.md
@@ -4,4 +4,7 @@ The home page now features a simple hero section with quick links to common task
 If you are signed in, the links display the number of students and curriculums you
 currently have. Use these links to jump straight to managing students, viewing
 curriculums or uploading work. A math skill selector is also available to
-generate a Mermaid DAG of prerequisites using the built‑in LLM client.
+generate a Mermaid DAG of prerequisites using the built‑in LLM client. The
+response streams back from the LLM. A progress bar below the **Generate**
+button fills as tokens arrive and the diagram updates whenever the partial JSON
+can be parsed.


### PR DESCRIPTION
## Summary
- stream LLM output in the generate-graph API
- update LLM client with `streamChat` helper
- progressively render graphs with a progress bar
- adjust tests for streaming
- document the streaming behaviour

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686d87ad9d04832ba347deae7c9b12b4