### PR TITLE
Fix missing breakpoints

### DIFF
--- a/app/drizzle/0000_fancy_blue_shield.sql
+++ b/app/drizzle/0000_fancy_blue_shield.sql
@@ -74,8 +74,8 @@ CREATE TABLE `user` (
 --> statement-breakpoint
 CREATE UNIQUE INDEX `user_email_unique` ON `user` (`email`);--> statement-breakpoint
 CREATE TABLE `verificationToken` (
-	`identifier` text NOT NULL,
-	`token` text NOT NULL,
-	`expires` integer NOT NULL,
-	PRIMARY KEY(`identifier`, `token`)
-);
+        `identifier` text NOT NULL,
+        `token` text NOT NULL,
+        `expires` integer NOT NULL,
+        PRIMARY KEY(`identifier`, `token`)
+);--> statement-breakpoint

--- a/app/drizzle/0002_uploaded_work_vec.sql
+++ b/app/drizzle/0002_uploaded_work_vec.sql
@@ -6,4 +6,4 @@ CREATE VIRTUAL TABLE uploaded_work_index USING vec0(
 INSERT INTO uploaded_work_index(work_id, vector)
 SELECT id, json_extract(embeddings, '$.data[0].embedding')
 FROM uploaded_work
-WHERE embeddings IS NOT NULL AND embeddings != '';
+WHERE embeddings IS NOT NULL AND embeddings != '';--> statement-breakpoint

--- a/app/drizzle/0003_quiet_virginia_dare.sql
+++ b/app/drizzle/0003_quiet_virginia_dare.sql
@@ -4,3 +4,4 @@ CREATE TABLE `tag` (
 );
 --> statement-breakpoint
 CREATE UNIQUE INDEX `tag_text_unique` ON `tag` (`text`);
+--> statement-breakpoint

--- a/app/drizzle/0004_tag_index.sql
+++ b/app/drizzle/0004_tag_index.sql
@@ -2,4 +2,4 @@
 CREATE VIRTUAL TABLE tag_index USING vec0(
   tag_id TEXT PRIMARY KEY,
   vector FLOAT[1536]
-);
+);--> statement-breakpoint

--- a/app/drizzle/0005_salty_wolfsbane.sql
+++ b/app/drizzle/0005_salty_wolfsbane.sql
@@ -4,5 +4,6 @@ CREATE TABLE `topic_dag` (
 	`topics` text NOT NULL,
 	`graph` text NOT NULL,
 	`createdAt` integer NOT NULL,
-	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+        FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
 );
+--> statement-breakpoint


### PR DESCRIPTION
## Summary
- ensure SQL migrations end with `--> statement-breakpoint`
- run formatting and update metadata

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686d8ef16338832ba6b459b13a34dda8