### PR TITLE
Fix missing drizzle breakpoints

### DIFF
--- a/app/drizzle/0000_fancy_blue_shield.sql
+++ b/app/drizzle/0000_fancy_blue_shield.sql
@@ -79,3 +79,5 @@ CREATE TABLE `verificationToken` (
 	`expires` integer NOT NULL,
 	PRIMARY KEY(`identifier`, `token`)
 );
+
+--> statement-breakpoint

--- a/app/drizzle/0002_uploaded_work_vec.sql
+++ b/app/drizzle/0002_uploaded_work_vec.sql
@@ -7,3 +7,5 @@ INSERT INTO uploaded_work_index(work_id, vector)
 SELECT id, json_extract(embeddings, '$.data[0].embedding')
 FROM uploaded_work
 WHERE embeddings IS NOT NULL AND embeddings != '';
+
+--> statement-breakpoint

--- a/app/drizzle/0003_quiet_virginia_dare.sql
+++ b/app/drizzle/0003_quiet_virginia_dare.sql
@@ -4,3 +4,5 @@ CREATE TABLE `tag` (
 );
 --> statement-breakpoint
 CREATE UNIQUE INDEX `tag_text_unique` ON `tag` (`text`);
+
+--> statement-breakpoint

--- a/app/drizzle/0004_tag_index.sql
+++ b/app/drizzle/0004_tag_index.sql
@@ -3,3 +3,5 @@ CREATE VIRTUAL TABLE tag_index USING vec0(
   tag_id TEXT PRIMARY KEY,
   vector FLOAT[1536]
 );
+
+--> statement-breakpoint

--- a/app/drizzle/0005_salty_wolfsbane.sql
+++ b/app/drizzle/0005_salty_wolfsbane.sql
@@ -6,3 +6,5 @@ CREATE TABLE `topic_dag` (
 	`createdAt` integer NOT NULL,
 	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
 );
+
+--> statement-breakpoint


### PR DESCRIPTION
## Summary
- append `--> statement-breakpoint` to end of earlier migration files

## Testing
- `pnpm run panda`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686d8ef16338832ba6b459b13a34dda8