### PR TITLE
Fix streaming graph response

### DIFF
--- a/app/src/app/api/generate-graph/route.ts
+++ b/app/src/app/api/generate-graph/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+import { OpenAI } from 'openai';
 import { LLMClient } from '@/llm/client';
 import { GraphSchema } from '@/graphSchema';
 
@@ -14,9 +15,43 @@ export async function POST(req: NextRequest) {
   } else {
     console.log('OPENAI_API_KEY loaded');
   }
+  const wantsStream = req.headers.get('accept') === 'text/event-stream';
+  const prompt = `Create a topic dependency graph flowing from left to right starting at kindergarten math and covering these topics: ${topics.join(', ')}. Use granular nodes and include prerequisite links.`;
+
+  if (wantsStream) {
+    const openai = new OpenAI({ apiKey: apiKey || '' });
+    const stream = await openai.chat.completions.create({
+      model: 'o4-mini',
+      stream: true,
+      max_completion_tokens: 800,
+      messages: [
+        { role: 'system', content: 'You are an expert math curriculum planner. Respond ONLY with JSON.' },
+        { role: 'user', content: prompt },
+      ],
+    });
+    const encoder = new TextEncoder();
+    const readable = new ReadableStream({
+      async start(controller) {
+        for await (const chunk of stream) {
+          const delta = chunk.choices[0]?.delta?.content;
+          if (delta) {
+            controller.enqueue(encoder.encode(`data: ${delta}\n\n`));
+          }
+        }
+        controller.close();
+      },
+    });
+    return new NextResponse(readable, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    });
+  }
+
   const client = new LLMClient(apiKey || '');
   const schema = z.object({ graph: GraphSchema });
-  const prompt = `Create a topic dependency graph flowing from left to right starting at kindergarten math and covering these topics: ${topics.join(', ')}. Use granular nodes and include prerequisite links.`;
   const result = await client.chat(prompt, {
     systemPrompt: 'You are an expert math curriculum planner.',
     schema,

--- a/app/src/components/MathSkillSelector.tsx
+++ b/app/src/components/MathSkillSelector.tsx
@@ -34,6 +34,8 @@ export function MathSkillSelector() {
   const [saved, setSaved] = useState(false);
   const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState(0);
+  const MAX_TOKENS = 800;
 
   const toggle = (skill: string) => {
     setSelected((prev) =>
@@ -44,10 +46,14 @@ export function MathSkillSelector() {
   const generate = async () => {
     setStatus('loading');
     setError(null);
+    setProgress(0);
     try {
       const res = await fetch('/api/generate-graph', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'text/event-stream',
+        },
         body: JSON.stringify({ topics: selected }),
       });
       if (!res.ok) {
@@ -56,10 +62,34 @@ export function MathSkillSelector() {
         setStatus('error');
         return;
       }
-      const data = (await res.json()) as { graph: Graph };
-      setGraph(data.graph);
-      setSaved(false);
-      setStatus('idle');
+      if (res.headers.get('content-type')?.includes('text/event-stream') && res.body) {
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        let count = 0;
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          const chunk = decoder.decode(value);
+          const clean = chunk.replace(/(^|\n)\s*data:\s*/g, '$1');
+          buffer += clean;
+          count += clean.split(/\s+/).length;
+          setProgress(count);
+          try {
+            const obj = JSON.parse(buffer) as { graph: Graph };
+            setGraph(obj.graph);
+          } catch {
+            // ignore partial JSON
+          }
+        }
+        setSaved(false);
+        setStatus('idle');
+      } else {
+        const data = (await res.json()) as { graph: Graph };
+        setGraph(data.graph);
+        setSaved(false);
+        setStatus('idle');
+      }
     } catch (err) {
       setError((err as Error).message);
       setStatus('error');
@@ -95,6 +125,16 @@ export function MathSkillSelector() {
       <button style={styles.button} onClick={generate}>
         Generate Graph
       </button>
+      <div style={{ width: '100%', background: '#eee', height: '0.5rem', marginTop: '0.5rem' }}>
+        <div
+          style={{
+            width: `${(progress / MAX_TOKENS) * 100}%`,
+            height: '100%',
+            background: '#4caf50',
+            transition: 'width 0.2s linear',
+          }}
+        />
+      </div>
       {status === 'loading' && (
         <p className={css({ color: 'blue.600', mt: '2' })}>Generating graph...</p>
       )}


### PR DESCRIPTION
## Summary
- correct OpenAI import and use max_completion_tokens
- prefix streamed chunks with SSE `data:` and strip prefix on the client
- adjust type in MathSkillSelector test

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`

Manual testing: Start the dev server with `pnpm dev`, generate a graph, and observe the progress bar and live graph updates during streaming.

------
https://chatgpt.com/codex/tasks/task_e_686d87ad9d04832ba347deae7c9b12b4