### PR TITLE
Use React Query mutation for student updates

### DIFF
--- a/app/src/components/StudentForm.stories.tsx
+++ b/app/src/components/StudentForm.stories.tsx
@@ -1,5 +1,6 @@
-import type { Meta } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react'
 import { StudentForm } from './StudentForm'
+import QueryProvider from './QueryProvider'
 
 const meta: Meta<typeof StudentForm> = {
   title: 'StudentForm',
@@ -7,4 +8,12 @@ const meta: Meta<typeof StudentForm> = {
 }
 export default meta
 
-export const Default = {}
+type Story = StoryObj<typeof StudentForm>
+
+export const Default: Story = {
+  render: () => (
+    <QueryProvider>
+      <StudentForm />
+    </QueryProvider>
+  ),
+}

--- a/app/src/components/StudentForm.test.tsx
+++ b/app/src/components/StudentForm.test.tsx
@@ -1,12 +1,17 @@
 import { render, fireEvent, screen } from '@testing-library/react'
 import { StudentForm } from './StudentForm'
+import QueryProvider from './QueryProvider'
 import '@testing-library/jest-dom'
 
 vi.mock('next/navigation', () => ({ useRouter: () => ({}) }))
 
 describe('StudentForm', () => {
   it('shows validation errors', async () => {
-    render(<StudentForm />)
+    render(
+      <QueryProvider>
+        <StudentForm />
+      </QueryProvider>
+    )
     fireEvent.submit(screen.getByRole('button'))
     expect(await screen.findByText('Name is required')).toBeInTheDocument()
   })

--- a/app/src/components/StudentForm.tsx
+++ b/app/src/components/StudentForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation } from '@tanstack/react-query'
 import {
   studentFieldsSchema,
   StudentFields,
@@ -24,18 +25,25 @@ export function StudentForm({ student, onSuccess }: Props) {
     },
   })
 
-  const onSubmit = async (data: StudentFields) => {
-    const res = await fetch(
-      student ? `/api/students/${student.id}` : '/api/students',
-      {
-        method: student ? 'PUT' : 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      }
-    )
-    if (res.ok) {
+  const mutation = useMutation({
+    mutationFn: async (data: StudentFields) => {
+      const res = await fetch(
+        student ? `/api/students/${student.id}` : '/api/students',
+        {
+          method: student ? 'PUT' : 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data),
+        }
+      )
+      if (!res.ok) throw new Error('Request failed')
+    },
+    onSuccess: () => {
       onSuccess?.()
-    }
+    },
+  })
+
+  const onSubmit = async (data: StudentFields) => {
+    await mutation.mutateAsync(data)
   }
 
   return (
@@ -44,7 +52,7 @@ export function StudentForm({ student, onSuccess }: Props) {
       {errors.name && <span>{errors.name.message}</span>}
       <input placeholder="Email" {...register('email')} />
       {errors.email && <span>{errors.email.message}</span>}
-      <button type="submit" disabled={isSubmitting}>
+      <button type="submit" disabled={isSubmitting || mutation.isPending}>
         {student ? 'Save' : 'Add'}
       </button>
     </form>


### PR DESCRIPTION
## Summary
- replace fetch update in `StudentForm` with `useMutation`
- wrap StudentForm with QueryProvider in stories and tests

## Testing
- `pnpm run format` *(fails: No files processed)*
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d88ff72d8832b8bf969cb3a26eb16