### PR TITLE
Refactor TopicDAGList to use React Query

### DIFF
--- a/app/src/components/TopicDAGList.test.tsx
+++ b/app/src/components/TopicDAGList.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { TopicDAGList } from './TopicDAGList'
 import type { Mock } from 'vitest'
 vi.mock('react-mermaid2', () => ({ default: () => <div data-testid="mermaid" /> }))
@@ -7,6 +8,28 @@ vi.stubGlobal('fetch', vi.fn())
 const mockFetch = fetch as unknown as Mock
 
 interface Dag { id: string; topics: string; graph: unknown; createdAt: string }
+
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        queryFn: async ({ queryKey }) => {
+          const [endpoint, init] = queryKey as [string, RequestInit?]
+          const url = endpoint.startsWith('/api')
+            ? endpoint
+            : `/api${endpoint}`
+          const res = await fetch(url, init)
+          if (!res.ok) throw new Error('Request failed')
+          return res.json()
+        },
+      },
+    },
+  })
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  )
+}
 
 function mockGet(dags: Dag[]) {
   mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ dags }) })
@@ -18,15 +41,17 @@ beforeEach(() => {
 
 test('loads DAGs on mount', async () => {
   mockGet([{ id: '1', topics: JSON.stringify(['A', 'B']), graph: { nodes: [{ id: 'a', label: 'A', desc: '', tags: ['t1','t2','t3'] }], edges: [] }, createdAt: new Date().toISOString() }])
-  render(<TopicDAGList />)
-  expect(mockFetch).toHaveBeenCalledWith('/api/topic-dags')
+  renderWithClient(<TopicDAGList />)
+  await waitFor(() => expect(mockFetch).toHaveBeenCalled())
+  expect(mockFetch).toHaveBeenCalledWith('/api/topic-dags', undefined)
   expect(await screen.findByText('A, B')).toBeInTheDocument()
 })
 
 test('shows graph when row clicked', async () => {
   const dag = { id: '1', topics: JSON.stringify(['A']), graph: { nodes: [{ id: 'a', label: 'A', desc: '', tags: ['t1','t2','t3'] }], edges: [] }, createdAt: new Date().toISOString() }
   mockGet([dag])
-  render(<TopicDAGList />)
+  renderWithClient(<TopicDAGList />)
+  await waitFor(() => expect(mockFetch).toHaveBeenCalled())
   const row = await screen.findByText('A')
   fireEvent.click(row)
   expect(await screen.findByTestId('mermaid')).toBeInTheDocument()

--- a/app/src/components/TopicDAGList.tsx
+++ b/app/src/components/TopicDAGList.tsx
@@ -1,5 +1,6 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import Mermaid from 'react-mermaid2'
 import { Graph } from '@/graphSchema'
 import { graphToMermaid } from '@/graphToMermaid'
@@ -12,20 +13,9 @@ interface Dag {
 }
 
 export function TopicDAGList() {
-  const [dags, setDags] = useState<Dag[]>([])
+  const { data } = useQuery<{ dags: Dag[] }>({ queryKey: ['/topic-dags'] })
+  const dags = data?.dags ?? []
   const [expanded, setExpanded] = useState<string | null>(null)
-
-  const load = async () => {
-    const res = await fetch('/api/topic-dags')
-    if (res.ok) {
-      const data = (await res.json()) as { dags: Dag[] }
-      setDags(data.dags)
-    }
-  }
-
-  useEffect(() => {
-    load()
-  }, [])
 
   return (
     <ul>


### PR DESCRIPTION
## Summary
- replace manual `fetch` in `TopicDAGList` with `useQuery`
- update tests for `TopicDAGList` to work with React Query

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build` *(fails: Failed to collect page data for /api/auth/[...nextauth])*

------
https://chatgpt.com/codex/tasks/task_e_686d88ee22a0832baf6c1bdd0c4f6255