### PR TITLE
Ignore drizzle meta directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 **/coverage
 app/prisma/dev.db
 app/node-compile-cache
+
+app/drizzle/meta/


### PR DESCRIPTION
## Summary
- ignore `app/drizzle/meta` in `.gitignore`

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686db5eb10b8832ba75b6fa77a53a893