### PR TITLE
Add markdown linting

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "default": true,
+  "MD012": false,
+  "MD013": false
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,39 +3,48 @@
 This repository is a Next.js TypeScript project that uses Biome for formatting and linting, Vitest for testing, and Panda CSS for styling.
 
 ## Setup
+
 - Run `pnpm install` before other commands. If Biome or Rollup binaries are missing afterwards, run:
   `pnpm install @biomejs/cli-linux-x64 @rollup/rollup-linux-x64-gnu`.
 
 ## Formatting and Linting
+
 - Run `pnpm run format` before committing to apply Biome's formatting.
 - Ensure `pnpm run lint` exits with no errors or warnings. If you changed Markdown files, run `pnpm run lint:md`.
 - A task is not complete until `pnpm run typecheck` succeeds and no new TypeScript errors remain.
 
 ## Testing
+
 - Execute `pnpm test` and `pnpm test:e2e` after linting. All tests must pass.
 - Use `pnpm build` to verify the project builds successfully.
 - Provide manual testing instructions for reviewers.
 
 ## Styles and UI
+
 - Use Panda CSS `css` utilities for new styles. Components should include Storybook stories and tests.
 
 ## Code Style
+
 - Use 2‑space indentation, double quotes for strings, and end statements with semicolons.
 - Import Node.js builtin modules using the `node:` protocol.
 - Avoid `z-index` unless absolutely necessary and reference a variable when used.
 
 ## Dates and Times
+
 - Parse and store timestamps in UTC ISO format. Let the client format and display dates.
 
 ## Next.js Dynamic APIs
+
 - Type `params` and `searchParams` as `Promise` objects and `await` them before use.
 
 ## Drizzle Migrations
+
 - Run `pnpm run generate-migrations` after schema changes. Migrations live in `app/drizzle` and are ordered via `app/drizzle/meta/_journal.json`. Under normal circumstances, there should be no need to edit a migration file after it has been generated. Exceptions may include adding something that the generated migration didn't pick up on, or transforming data along with the migration.
 - Each SQL statement in a migration must end with `--> statement-breakpoint`. The command above generates these breakpoints and updates the journal file.
 - `src/db/index.ts` runs migrations on startup when the `drizzle` folder exists. Commit both the new SQL and updated metadata.
 
 ## Other Rules
+
 - Never manually edit files under `src/generated`.
 - Commit updates to `pnpm-lock.yaml` in full and ensure the diff starts with `lockfileVersion` and ends with a newline. Never ever edit pnpm-lock by hand. If you need a change start first by looking at what you can change in package.json and then regenerate the lockfile.
 - Follow [Semantic Commit Messages](https://www.conventionalcommits.org/).

--- a/app/README.md
+++ b/app/README.md
@@ -1,3 +1,5 @@
+# Choose Your Own Curriculum App
+
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
 ## Getting Started

--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,7 @@
     "generate-migrations": "pnpm exec drizzle-kit generate",
     "build": "panda && next build",
     "start": "next start",
-    "lint": "biome check .",
+    "lint": "biome check . && pnpm run lint:md",
     "format": "biome format --write .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
@@ -19,7 +19,8 @@
     "storybook": "storybook dev -p 6006 --ci",
     "build-storybook": "storybook build",
     "panda": "panda",
-    "fetch-tags-for-embeddings": "tsx scripts/fetch-tags-for-embeddings.ts"
+    "fetch-tags-for-embeddings": "tsx scripts/fetch-tags-for-embeddings.ts",
+    "lint:md": "sh -c 'cd .. && markdownlint \"**/*.md\" --ignore node_modules'"
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.10.0",
@@ -75,6 +76,7 @@
     "eslint-config-next": "15.3.5",
     "eslint-plugin-storybook": "^9.0.15",
     "jsdom": "^26.1.0",
+    "markdownlint-cli": "0.39.0",
     "playwright": "^1.53.2",
     "storybook": "^9.0.15",
     "tsx": "^4.20.3",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
+      markdownlint-cli:
+        specifier: 0.39.0
+        version: 0.39.0
       playwright:
         specifier: ^1.53.2
         version: 1.53.2
@@ -3468,6 +3471,10 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+
   commander@2.17.1:
     resolution: {integrity: sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==}
 
@@ -5113,6 +5120,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stdin@9.0.0:
+    resolution: {integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==}
+    engines: {node: '>=12'}
+
   get-stream@4.1.0:
     resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
     engines: {node: '>=6'}
@@ -5147,6 +5158,11 @@ packages:
 
   glob-to-regexp@0.3.0:
     resolution: {integrity: sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig==}
+
+  glob@10.3.16:
+    resolution: {integrity: sha512-JDKXl1DiuuHJ6fVS2FXjownaavciiHNUU4mOvV/B793RLh05vZL1rcPnCSaOgv1hDT6RDlY7AB7ZUvFYAtPgAw==}
+    engines: {node: '>=16 || 14 >=14.18'}
+    hasBin: true
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
@@ -5492,6 +5508,10 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ini@4.1.3:
+    resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   inquirer@7.0.4:
     resolution: {integrity: sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==}
@@ -6090,6 +6110,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@3.2.1:
+    resolution: {integrity: sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==}
+
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
@@ -6254,6 +6277,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   load-json-file@2.0.0:
     resolution: {integrity: sha512-3p6ZOGNbiX4CdvEd1VcE6yi78UrGNpjHO33noGwHCnT/o2fyllJDepsm8+mFFv/DvtwFHht5HIHSyOy5a+ChVQ==}
     engines: {node: '>=4'}
@@ -6399,6 +6425,23 @@ packages:
     resolution: {integrity: sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==}
     engines: {node: '>=0.10.0'}
 
+  markdown-it@14.0.0:
+    resolution: {integrity: sha512-seFjF0FIcPt4P9U39Bq1JYblX0KZCjDLFFQPHpL5AzHpqPEKtosxmdq/LTVZnjfH7tjt9BxStm+wXcDBNuYmzw==}
+    hasBin: true
+
+  markdownlint-cli@0.39.0:
+    resolution: {integrity: sha512-ZuFN7Xpsbn1Nbp0YYkeLOfXOMOfLQBik2lKRy8pVI/llmKQ2uW7x+8k5OMgF6o7XCsTDSYC/OOmeJ+3qplvnJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  markdownlint-micromark@0.1.8:
+    resolution: {integrity: sha512-1ouYkMRo9/6gou9gObuMDnvZM8jC/ly3QCFQyoSPCS2XV1ZClU0xpKbL1Ar3bWWRT1RnBZkWUEiNKrI2CwiBQA==}
+    engines: {node: '>=16'}
+
+  markdownlint@0.33.0:
+    resolution: {integrity: sha512-4lbtT14A3m0LPX1WS/3d1m7Blg+ZwiLq36WvjQqFGsX3Gik99NV+VXp/PW3n+Q62xyPdbvGOCfjPqjW+/SKMig==}
+    engines: {node: '>=18'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -6411,6 +6454,9 @@ packages:
 
   mdn-data@2.0.4:
     resolution: {integrity: sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -7719,6 +7765,10 @@ packages:
   pumpify@1.5.1:
     resolution: {integrity: sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@1.4.1:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
 
@@ -8126,6 +8176,10 @@ packages:
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
+
+  run-con@1.3.2:
+    resolution: {integrity: sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==}
+    hasBin: true
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -9065,6 +9119,9 @@ packages:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
@@ -13902,6 +13959,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@11.1.0: {}
+
   commander@2.17.1: {}
 
   commander@2.19.0: {}
@@ -15926,6 +15985,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stdin@9.0.0: {}
+
   get-stream@4.1.0:
     dependencies:
       pump: 3.0.3
@@ -15962,6 +16023,14 @@ snapshots:
       is-glob: 4.0.3
 
   glob-to-regexp@0.3.0: {}
+
+  glob@10.3.16:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      path-scurry: 1.11.1
 
   glob@10.4.5:
     dependencies:
@@ -16345,6 +16414,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  ini@4.1.3: {}
 
   inquirer@7.0.4:
     dependencies:
@@ -17209,6 +17280,8 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-parser@3.2.1: {}
+
   jsonc-parser@3.3.1: {}
 
   jsonfile@4.0.0:
@@ -17351,6 +17424,10 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.25.1
 
   lines-and-columns@1.2.4: {}
+
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
 
   load-json-file@2.0.0:
     dependencies:
@@ -17518,6 +17595,34 @@ snapshots:
     dependencies:
       object-visit: 1.0.1
 
+  markdown-it@14.0.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  markdownlint-cli@0.39.0:
+    dependencies:
+      commander: 11.1.0
+      get-stdin: 9.0.0
+      glob: 10.3.16
+      ignore: 5.3.2
+      js-yaml: 4.1.0
+      jsonc-parser: 3.2.1
+      markdownlint: 0.33.0
+      minimatch: 9.0.5
+      run-con: 1.3.2
+
+  markdownlint-micromark@0.1.8: {}
+
+  markdownlint@0.33.0:
+    dependencies:
+      markdown-it: 14.0.0
+      markdownlint-micromark: 0.1.8
+
   math-intrinsics@1.1.0: {}
 
   md5.js@1.3.5:
@@ -17529,6 +17634,8 @@ snapshots:
   mdn-data@2.0.14: {}
 
   mdn-data@2.0.4: {}
+
+  mdurl@2.0.0: {}
 
   media-typer@0.3.0: {}
 
@@ -19030,6 +19137,8 @@ snapshots:
       inherits: 2.0.4
       pump: 2.0.1
 
+  punycode.js@2.3.1: {}
+
   punycode@1.4.1: {}
 
   punycode@2.3.1: {}
@@ -19601,6 +19710,13 @@ snapshots:
   rsvp@4.8.5: {}
 
   run-async@2.4.1: {}
+
+  run-con@1.3.2:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 4.1.3
+      minimist: 1.2.8
+      strip-json-comments: 3.1.1
 
   run-parallel@1.2.0:
     dependencies:
@@ -20720,6 +20836,8 @@ snapshots:
   typescript@5.6.2: {}
 
   typescript@5.8.3: {}
+
+  uc.micro@2.1.0: {}
 
   ufo@1.6.1: {}
 


### PR DESCRIPTION
## Summary
- add `.markdownlint.json` config
- install `markdownlint-cli`
- run markdown lint as part of `pnpm run lint`
- add `pnpm run lint:md` script
- enforce additional markdown rules and fix existing files

## Testing
- `pnpm run lint`
- `pnpm run lint:md`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run test:e2e`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_686db1db80ac832ba1ab338c12fa9f0f