### PR TITLE
Add simple E2E student test

### DIFF
--- a/app/tests/e2e/students.test.ts
+++ b/app/tests/e2e/students.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import { GET } from '@/app/api/students/route';
+import { getServerSession } from 'next-auth';
+
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }));
+vi.mock('@/authOptions', () => ({ authOptions: {} }));
+vi.mock('@/db', () => ({ getDb: vi.fn() }));
+
+describe('students API', () => {
+  it('requires auth for GET', async () => {
+    (getServerSession as unknown as Mock).mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Playwright/Vitest e2e test for unauthorized student listing

## Testing
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_686db73fff5c832b904e806f7b0773e4