### PR TITLE
Add students API e2e test

### DIFF
--- a/app/tests/e2e/students.test.ts
+++ b/app/tests/e2e/students.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import { GET as getStudents } from '@/app/api/students/route';
+import { getServerSession } from 'next-auth';
+
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }));
+vi.mock('@/authOptions', () => ({ authOptions: {} }));
+vi.mock('@/db', () => {
+  const where = vi.fn().mockResolvedValue([{ id: '1', name: 'Alice', email: 'a@example.com' }]);
+  const innerJoin = vi.fn(() => ({ where }));
+  const from = vi.fn(() => ({ innerJoin, where }));
+  const select = vi.fn(() => ({ from }));
+  const db = { select };
+  const sqlite = { prepare: vi.fn(), transaction: vi.fn() };
+  return { getDb: () => db, getSqlite: () => sqlite };
+});
+
+describe('students API', () => {
+  it('rejects unauthenticated users', async () => {
+    (getServerSession as unknown as Mock).mockResolvedValue(null);
+    const res = await getStudents();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns student list when authenticated', async () => {
+    (getServerSession as unknown as Mock).mockResolvedValue({ user: { id: 'u1' } });
+    const res = await getStudents();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.students[0].id).toBe('1');
+  });
+});


### PR DESCRIPTION
## Summary
- add missing e2e coverage for students API

## Testing
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686db73fff5c832b904e806f7b0773e4