### PR TITLE
Add e2e test for students API

### DIFF
--- a/app/tests/e2e/students.test.ts
+++ b/app/tests/e2e/students.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST as createStudent } from '@/app/api/students/route';
+import { getServerSession } from 'next-auth';
+
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }));
+vi.mock('@/authOptions', () => ({ authOptions: {} }));
+vi.mock('@/db', () => {
+  const where = vi.fn().mockResolvedValue([]);
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+  const returning = vi.fn().mockResolvedValue([{ id: 's1' }]);
+  const values = vi.fn(() => ({ returning }));
+  const insert = vi.fn(() => ({ values }));
+  const db = { select, insert };
+  return { getDb: () => db };
+});
+
+describe('students API', () => {
+  it('creates a student', async () => {
+    (getServerSession as unknown as Mock).mockResolvedValue({ user: { id: 'u1' } });
+    const req = new NextRequest(new Request('http://localhost/api/students', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Alice', email: '' }),
+      headers: { 'content-type': 'application/json' }
+    }));
+    const res = await createStudent(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.id).toBe('s1');
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for `POST /api/students`

## Testing
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686db73fff5c832b904e806f7b0773e4