### PR TITLE
Handle missing thumbnails for uploads

### DIFF
--- a/app/src/components/ThumbnailPlaceholder.stories.tsx
+++ b/app/src/components/ThumbnailPlaceholder.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta } from '@storybook/react'
+import { ThumbnailPlaceholder } from './ThumbnailPlaceholder'
+
+const meta: Meta<typeof ThumbnailPlaceholder> = {
+  title: 'ThumbnailPlaceholder',
+  component: ThumbnailPlaceholder,
+}
+export default meta
+
+export const Default = {}

--- a/app/src/components/ThumbnailPlaceholder.test.tsx
+++ b/app/src/components/ThumbnailPlaceholder.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react'
+import { ThumbnailPlaceholder } from './ThumbnailPlaceholder'
+import '@testing-library/jest-dom'
+
+describe('ThumbnailPlaceholder', () => {
+  it('shows extension in uppercase', () => {
+    render(<ThumbnailPlaceholder mime="application/pdf" />)
+    expect(screen.getByTestId('thumbnail-placeholder')).toHaveTextContent('PDF')
+  })
+})

--- a/app/src/components/ThumbnailPlaceholder.tsx
+++ b/app/src/components/ThumbnailPlaceholder.tsx
@@ -1,0 +1,24 @@
+'use client'
+import { css } from '@/styled-system/css'
+
+export function ThumbnailPlaceholder({ mime }: { mime?: string | null }) {
+  const ext = mime?.split('/').pop()?.toUpperCase() || ''
+  return (
+    <div
+      data-testid="thumbnail-placeholder"
+      className={css({
+        width: '1.5in',
+        height: '1.5in',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderWidth: '1px',
+        borderColor: 'gray.300',
+        color: 'gray.600',
+        fontSize: 'sm',
+      })}
+    >
+      {ext}
+    </div>
+  )
+}

--- a/app/src/components/UploadedWorkList.test.tsx
+++ b/app/src/components/UploadedWorkList.test.tsx
@@ -20,6 +20,7 @@ interface Work {
   dateCompleted: string | null
   tags: Tag[]
   hasThumbnail: boolean
+  originalMimeType: string | null
 }
 
 function mockGet(works: Work[]) {
@@ -33,19 +34,20 @@ describe('UploadedWorkList', () => {
   })
 
   it('loads works on mount', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ students: [] }) })
-    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ students: [] }) })
-    mockGet([
-      {
-        id: '1',
-        studentId: 's1',
-        summary: 'sum',
-        dateUploaded: new Date().toISOString(),
-        dateCompleted: null,
-        tags: [{ text: 't1', vector: [0, 0, 0] }],
-        hasThumbnail: true,
-      },
-    ])
+  mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ students: [] }) })
+  mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ students: [] }) })
+  mockGet([
+    {
+      id: '1',
+      studentId: 's1',
+      summary: 'sum',
+      dateUploaded: new Date().toISOString(),
+      dateCompleted: null,
+      tags: [{ text: 't1', vector: [0, 0, 0] }],
+      hasThumbnail: true,
+      originalMimeType: 'image/png',
+    },
+  ])
     render(
       <QueryProvider>
         <UploadedWorkList />
@@ -60,6 +62,30 @@ describe('UploadedWorkList', () => {
       'src',
       '/api/upload-work/1?type=thumbnail'
     )
+  })
+
+  it('shows placeholder when thumbnail missing', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ students: [] }) })
+    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ students: [] }) })
+    mockGet([
+      {
+        id: '2',
+        studentId: 's1',
+        summary: 'sum2',
+        dateUploaded: new Date().toISOString(),
+        dateCompleted: null,
+        tags: [],
+        hasThumbnail: false,
+        originalMimeType: 'application/pdf',
+      },
+    ])
+    render(
+      <QueryProvider>
+        <UploadedWorkList />
+      </QueryProvider>
+    )
+    const placeholder = await screen.findByTestId('thumbnail-placeholder')
+    expect(placeholder).toHaveTextContent('PDF')
   })
 
 })

--- a/app/src/components/UploadedWorkList.tsx
+++ b/app/src/components/UploadedWorkList.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { UploadForm } from './UploadForm'
 import { TagPill } from './TagPill'
+import { ThumbnailPlaceholder } from './ThumbnailPlaceholder'
 import { useTranslation } from 'react-i18next'
 
 interface Tag {
@@ -19,6 +20,7 @@ interface Work {
   dateCompleted: string | null
   tags: Tag[]
   hasThumbnail: boolean
+  originalMimeType: string | null
 }
 
 export function UploadedWorkList({ studentId = '' }: { studentId?: string } = {}) {
@@ -30,6 +32,7 @@ export function UploadedWorkList({ studentId = '' }: { studentId?: string } = {}
   const [filterDay, setFilterDay] = useState('')
   const [filterTag, setFilterTag] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [thumbError, setThumbError] = useState<Record<string, boolean>>({})
   const { t } = useTranslation()
 
   useEffect(() => {
@@ -133,12 +136,15 @@ export function UploadedWorkList({ studentId = '' }: { studentId?: string } = {}
                 key={w.id}
                 style={{ marginBottom: '1rem', display: 'flex', gap: '0.5rem' }}
               >
-                {w.hasThumbnail && (
+                {w.hasThumbnail && !thumbError[w.id] ? (
                   <img
                     src={`/api/upload-work/${w.id}?type=thumbnail`}
                     alt="thumbnail"
                     style={{ maxWidth: '1.5in', maxHeight: '1.5in' }}
+                    onError={() => setThumbError((e) => ({ ...e, [w.id]: true }))}
                   />
+                ) : (
+                  <ThumbnailPlaceholder mime={w.originalMimeType} />
                 )}
                 <div>
                   <strong>

--- a/docs/usage/uploaded_work.md
+++ b/docs/usage/uploaded_work.md
@@ -6,4 +6,6 @@ Each upload appears in the list with its summary for easy review. New uploads sh
 
 Image uploads also generate a thumbnail shown to the left of the summary. Thumbnails are sized to at most 1.5 inches on each side while preserving aspect ratio.
 
+If no thumbnail is available or a file type isn't supported, a placeholder icon displays the file's extension instead.
+
 Math expressions wrapped in `$...$`, `$$...$$`, `\(...\)` or `\[...\]` in summaries are rendered with KaTeX.


### PR DESCRIPTION
## Summary
- add `ThumbnailPlaceholder` component and tests
- show placeholder for uploads with no thumbnail
- update docs on placeholder behavior

## Testing
- `pnpm --filter app run lint`
- `pnpm --filter app run typecheck`
- `pnpm --filter app test`
- `pnpm --filter app test:e2e`
- `pnpm --filter app run build`


------
https://chatgpt.com/codex/tasks/task_e_686db6e09db4832b9d31b08bf23d0bb2