### PR TITLE
Show tags on graph node hover

### DIFF
--- a/app/src/components/StudentCurriculum.tsx
+++ b/app/src/components/StudentCurriculum.tsx
@@ -1,9 +1,10 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import Mermaid from 'react-mermaid2'
 import { Graph } from '@/graphSchema'
 import { graphToMermaid } from '@/graphToMermaid'
+import { addMermaidTags } from '@/lib/mermaidTags'
 
 interface Dag {
   id: string
@@ -22,6 +23,7 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
   const [dags, setDags] = useState<Dag[]>([])
   const [selected, setSelected] = useState('')
   const { t } = useTranslation()
+  const graphRef = useRef<HTMLDivElement | null>(null)
 
   const load = async () => {
     const res = await fetch(`/api/students/${studentId}`)
@@ -66,6 +68,12 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [studentId])
 
+  useEffect(() => {
+    if (data?.graph) {
+      addMermaidTags(graphRef.current, data.graph)
+    }
+  }, [data?.graph])
+
   if (!data) return null
 
   if (!data.topicDagId) {
@@ -97,7 +105,7 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
       <h2>{t('curriculum')}</h2>
       <div>{data.topics.join(', ')}</div>
       {data.graph && (
-        <div style={{ marginTop: '1rem' }}>
+        <div style={{ marginTop: '1rem' }} ref={graphRef}>
           <Mermaid chart={graphToMermaid(data.graph)} />
         </div>
       )}

--- a/app/src/components/TopicDAGList.tsx
+++ b/app/src/components/TopicDAGList.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useRef } from 'react'
 import Mermaid from 'react-mermaid2'
 import { Graph } from '@/graphSchema'
 import { graphToMermaid } from '@/graphToMermaid'
+import { addMermaidTags } from '@/lib/mermaidTags'
 
 interface Dag {
   id: string
@@ -62,7 +63,10 @@ export function TopicDAGList() {
               : `Tag processing: ${d.tagEmbeddingsComplete}/${d.tagEmbeddingsTotal}`}
           </div>
           {expanded === d.id && (
-            <div style={{ marginTop: '1rem' }}>
+            <div
+              style={{ marginTop: '1rem' }}
+              ref={(el) => addMermaidTags(el, d.graph)}
+            >
               <Mermaid chart={graphToMermaid(d.graph)} />
             </div>
           )}

--- a/app/src/lib/mermaidTags.ts
+++ b/app/src/lib/mermaidTags.ts
@@ -1,0 +1,26 @@
+import { Graph } from '@/graphSchema';
+
+export function addMermaidTags(container: HTMLElement | null, graph: Graph) {
+  if (!container) return;
+  const tryAdd = () => {
+    const svg = container.querySelector('svg');
+    if (!svg) {
+      setTimeout(tryAdd, 50);
+      return;
+    }
+    for (const node of graph.nodes) {
+      const g = svg.querySelector<SVGGElement>(`#${node.id}`);
+      if (!g) continue;
+      let title = g.querySelector<SVGTitleElement>('title');
+      if (!title) {
+        title = document.createElementNS(
+          'http://www.w3.org/2000/svg',
+          'title'
+        ) as SVGTitleElement;
+        g.appendChild(title);
+      }
+      title.textContent = node.tags.join(', ');
+    }
+  };
+  tryAdd();
+}


### PR DESCRIPTION
## Summary
- add helper to attach tags to mermaid nodes
- display node tags in StudentCurriculum and TopicDAGList graphs

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_686db84a76f0832ba522a29f68d283fe