### PR TITLE
Fix thumbnail orientation

### DIFF
--- a/app/src/app/api/upload-work/route.ts
+++ b/app/src/app/api/upload-work/route.ts
@@ -53,6 +53,7 @@ export async function POST(req: NextRequest) {
   if (isImage) {
     try {
       thumbnail = await sharp(buffer)
+        .rotate()
         .resize({ width: 144, height: 144, fit: 'inside' })
         .png()
         .toBuffer();

--- a/docs/usage/uploaded_work.md
+++ b/docs/usage/uploaded_work.md
@@ -4,6 +4,6 @@ Authenticated users can upload documents from the **Uploaded Work** page. The se
 
 Each upload appears in the list with its summary for easy review. New uploads show a temporary `Processing...` placeholder while the summary is generated. Any errors are shown next to the list.
 
-Image uploads also generate a thumbnail shown to the left of the summary. Thumbnails are sized to at most 1.5 inches on each side while preserving aspect ratio.
+Image uploads also generate a thumbnail shown to the left of the summary. The server reads orientation metadata to ensure thumbnails are rotated correctly. Thumbnails are sized to at most 1.5 inches on each side while preserving aspect ratio.
 
 Math expressions wrapped in `$...$`, `$$...$$`, `\(...\)` or `\[...\]` in summaries are rendered with KaTeX.


### PR DESCRIPTION
## Summary
- rotate thumbnails based on image orientation metadata
- note orientation in the uploaded work docs

## Testing
- `pnpm run format` *(shows no files were processed)*
- `pnpm run lint`
- `pnpm run lint:md` *(fails: Missing script)*
- `pnpm run panda`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686db685ef10832b8db9fd178dde162e