### PR TITLE
Fix thumbnail orientation

### DIFF
--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -16862,9 +16862,7 @@ snapshots:
       pretty-format: 24.9.0
       throat: 4.1.0
     transitivePeerDependencies:
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   jest-leak-detector@24.9.0:
     dependencies:

--- a/app/src/app/api/upload-work/route.ts
+++ b/app/src/app/api/upload-work/route.ts
@@ -53,6 +53,7 @@ export async function POST(req: NextRequest) {
   if (isImage) {
     try {
       thumbnail = await sharp(buffer)
+        .rotate()
         .resize({ width: 144, height: 144, fit: 'inside' })
         .png()
         .toBuffer();

--- a/app/src/thumbnailOrientation.test.ts
+++ b/app/src/thumbnailOrientation.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import sharp from 'sharp';
+
+async function makeTestImage() {
+  const img = sharp({ create: { width: 100, height: 50, channels: 3, background: '#0000ff' } });
+  const buffer = await img.jpeg().withMetadata({ orientation: 6 }).toBuffer();
+  return buffer;
+}
+
+describe('thumbnail orientation', () => {
+  it('applies EXIF rotation before resizing', async () => {
+    const buffer = await makeTestImage();
+    const thumb = await sharp(buffer)
+      .rotate()
+      .resize({ width: 144, height: 144, fit: 'inside' })
+      .png()
+      .toBuffer();
+    const meta = await sharp(thumb).metadata();
+    expect(meta.width).toBe(72);
+    expect(meta.height).toBe(144);
+  });
+});

--- a/docs/usage/uploaded_work.md
+++ b/docs/usage/uploaded_work.md
@@ -5,5 +5,6 @@ Authenticated users can upload documents from the **Uploaded Work** page. The se
 Each upload appears in the list with its summary for easy review. New uploads show a temporary `Processing...` placeholder while the summary is generated. Any errors are shown next to the list.
 
 Image uploads also generate a thumbnail shown to the left of the summary. Thumbnails are sized to at most 1.5 inches on each side while preserving aspect ratio.
+The server reads the image's orientation metadata so thumbnails are rotated correctly.
 
 Math expressions wrapped in `$...$`, `$$...$$`, `\(...\)` or `\[...\]` in summaries are rendered with KaTeX.


### PR DESCRIPTION
## Summary
- rotate thumbnails based on image metadata so they're always upright
- test sharp rotation logic
- document that thumbnails respect image orientation

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686db685ef10832b8db9fd178dde162e