### PR TITLE
feat: add i18n support for various strings

### DIFF
--- a/app/src/app/profile/[id]/page.tsx
+++ b/app/src/app/profile/[id]/page.tsx
@@ -1,10 +1,17 @@
 import { UserProfile } from '@/components/UserProfile'
+import { initI18n } from '@/i18n'
 
 export default async function ProfilePage({
   params,
 }: {
   params: Promise<{ id: string }>
 }) {
+  const i18n = await initI18n('en')
   const { id } = await params
-  return <UserProfile name={`User ${id}`} bio="This is the bio." />
+  return (
+    <UserProfile
+      name={i18n.t('userName', { id })}
+      bio={i18n.t('defaultBio')}
+    />
+  )
 }

--- a/app/src/components/Greeting.test.tsx
+++ b/app/src/components/Greeting.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import { Greeting } from './Greeting';
+import I18nProvider from './I18nProvider';
 
-test('renders greeting', () => {
-  render(<Greeting name="Test" />);
-  expect(screen.getByText('Hello Test')).toBeInTheDocument();
+test('renders greeting', async () => {
+  render(
+    <I18nProvider lng="en">
+      <Greeting name="Test" />
+    </I18nProvider>
+  );
+  expect(await screen.findByText('Hello Test')).toBeInTheDocument();
 });

--- a/app/src/components/Greeting.tsx
+++ b/app/src/components/Greeting.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
 type Props = { name: string };
 
 const styles = {
@@ -7,5 +9,6 @@ const styles = {
 };
 
 export function Greeting({ name }: Props) {
-  return <span style={styles.root}>Hello {name}</span>;
+  const { t } = useTranslation();
+  return <span style={styles.root}>{t('greeting', { name })}</span>;
 }

--- a/app/src/components/MathSkillSelector.test.tsx
+++ b/app/src/components/MathSkillSelector.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import type { Mock } from 'vitest';
 vi.mock('react-mermaid2', () => ({ default: () => <div data-testid="mermaid" /> }));
 import { MathSkillSelector } from './MathSkillSelector';
+import I18nProvider from './I18nProvider';
 
 vi.stubGlobal('fetch', vi.fn());
 const mockFetch = fetch as unknown as Mock;
@@ -16,9 +17,13 @@ test('calls API with selected topics and saves', async () => {
     })
   );
   mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ ok: true }) });
-  render(<MathSkillSelector />);
-  await user.click(screen.getByLabelText('Algebra'));
-  await user.click(screen.getByText('Generate Graph'));
+  render(
+    <I18nProvider lng="en">
+      <MathSkillSelector />
+    </I18nProvider>
+  );
+  await user.click(await screen.findByLabelText('Algebra'));
+  await user.click(await screen.findByText('Generate Graph'));
   expect(await screen.findByText('Generating graph...')).toBeInTheDocument();
   resolveFetch!({ ok: true, json: () => Promise.resolve({ graph: { nodes: [{ id: 'a', label: 'A', desc: '', tags: ['t1','t2','t3'] }], edges: [] } }) });
   expect(mockFetch).toHaveBeenCalledWith('/api/generate-graph', expect.objectContaining({ method: 'POST' }));
@@ -37,7 +42,11 @@ test('shows error message on failure', async () => {
     ok: false,
     json: () => Promise.resolve({ error: 'bad' }),
   });
-  render(<MathSkillSelector />);
-  await user.click(screen.getByText('Generate Graph'));
+  render(
+    <I18nProvider lng="en">
+      <MathSkillSelector />
+    </I18nProvider>
+  );
+  await user.click(await screen.findByText('Generate Graph'));
   expect(await screen.findByText('Failed to generate graph: bad. Please try again later.')).toBeInTheDocument();
 });

--- a/app/src/components/MathSkillSelector.tsx
+++ b/app/src/components/MathSkillSelector.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { css } from '@/styled-system/css';
 import Mermaid from 'react-mermaid2';
 import { Graph } from '@/graphSchema';
@@ -34,6 +35,7 @@ export function MathSkillSelector() {
   const [saved, setSaved] = useState(false);
   const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
+  const { t } = useTranslation();
 
   const toggle = (skill: string) => {
     setSelected((prev) =>
@@ -93,19 +95,19 @@ export function MathSkillSelector() {
         ))}
       </div>
       <button style={styles.button} onClick={generate}>
-        Generate Graph
+        {t('generateGraph')}
       </button>
       {status === 'loading' && (
-        <p className={css({ color: 'blue.600', mt: '2' })}>Generating graph...</p>
+        <p className={css({ color: 'blue.600', mt: '2' })}>{t('generatingGraph')}</p>
       )}
       {status === 'error' && (
         <p className={css({ color: 'red.600', mt: '2' })}>
-          Failed to generate graph: {error}. Please try again later.
+          {t('failedGenerateGraph', { error })}
         </p>
       )}
       {graph && (
         <button style={styles.button} onClick={save} disabled={saved}>
-          {saved ? 'Saved' : 'Save Graph'}
+          {saved ? t('saved') : t('saveGraph')}
         </button>
       )}
       {graph && (

--- a/app/src/components/UploadedWorkList.tsx
+++ b/app/src/components/UploadedWorkList.tsx
@@ -136,7 +136,7 @@ export function UploadedWorkList({ studentId = '' }: { studentId?: string } = {}
                 {w.hasThumbnail && (
                   <img
                     src={`/api/upload-work/${w.id}?type=thumbnail`}
-                    alt="thumbnail"
+                    alt={t('thumbnailAlt')}
                     style={{ maxWidth: '1.5in', maxHeight: '1.5in' }}
                   />
                 )}

--- a/app/src/locales/en/common.json
+++ b/app/src/locales/en/common.json
@@ -41,4 +41,14 @@
   "studentCount_other": "{{count}} students",
   "curriculumCount_one": "{{count}} curriculum",
   "curriculumCount_other": "{{count}} curriculums"
+  ,
+  "greeting": "Hello {{name}}",
+  "userName": "User {{id}}",
+  "defaultBio": "This is the bio.",
+  "thumbnailAlt": "thumbnail",
+  "generateGraph": "Generate Graph",
+  "generatingGraph": "Generating graph...",
+  "failedGenerateGraph": "Failed to generate graph: {{error}}. Please try again later.",
+  "saveGraph": "Save Graph",
+  "saved": "Saved"
 }

--- a/app/src/locales/es/common.json
+++ b/app/src/locales/es/common.json
@@ -41,4 +41,14 @@
   "studentCount_other": "{{count}} estudiantes",
   "curriculumCount_one": "{{count}} currículo",
   "curriculumCount_other": "{{count}} currículos"
+  ,
+  "greeting": "Hola {{name}}",
+  "userName": "Usuario {{id}}",
+  "defaultBio": "Esta es la biografía.",
+  "thumbnailAlt": "miniatura",
+  "generateGraph": "Generar gráfico",
+  "generatingGraph": "Generando gráfico...",
+  "failedGenerateGraph": "Error al generar el gráfico: {{error}}. Inténtalo de nuevo más tarde.",
+  "saveGraph": "Guardar gráfico",
+  "saved": "Guardado"
 }

--- a/app/src/locales/fr/common.json
+++ b/app/src/locales/fr/common.json
@@ -41,4 +41,14 @@
   "studentCount_other": "{{count}} étudiants",
   "curriculumCount_one": "{{count}} programme",
   "curriculumCount_other": "{{count}} programmes"
+  ,
+  "greeting": "Bonjour {{name}}",
+  "userName": "Utilisateur {{id}}",
+  "defaultBio": "Ceci est la biographie.",
+  "thumbnailAlt": "miniature",
+  "generateGraph": "Générer le graphique",
+  "generatingGraph": "Génération du graphique...",
+  "failedGenerateGraph": "Échec de la génération du graphique : {{error}}. Veuillez réessayer plus tard.",
+  "saveGraph": "Enregistrer le graphique",
+  "saved": "Enregistré"
 }


### PR DESCRIPTION
## Summary
- convert Greeting component to use i18n
- localize profile page strings
- localize thumbnail alt text
- localize math skill selector UI
- add new translation keys in en/es/fr
- update tests for async i18n provider

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686db70ba6d0832b9230e63cecdee6ce