### PR TITLE
Allow free text notes as student work

### DIFF
--- a/app/drizzle/0008_crazy_rhodey.sql
+++ b/app/drizzle/0008_crazy_rhodey.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `uploaded_work` ADD `note` text;
+--> statement-breakpoint

--- a/app/drizzle/meta/0008_snapshot.json
+++ b/app/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,734 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f365b78e-4a88-4309-b723-c1d6c803a901",
+  "prevId": "8c849e10-c359-42b2-b0da-81c21def18b5",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "name": "account_provider_providerAccountId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authenticator": {
+      "name": "authenticator",
+      "columns": {
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialPublicKey": {
+          "name": "credentialPublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialDeviceType": {
+          "name": "credentialDeviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialBackedUp": {
+          "name": "credentialBackedUp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authenticator_credentialID_unique": {
+          "name": "authenticator_credentialID_unique",
+          "columns": [
+            "credentialID"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "authenticator_userId_user_id_fk": {
+          "name": "authenticator_userId_user_id_fk",
+          "tableFrom": "authenticator",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authenticator_userId_credentialID_pk": {
+          "columns": [
+            "userId",
+            "credentialID"
+          ],
+          "name": "authenticator_userId_credentialID_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "student": {
+      "name": "student",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accountUserId": {
+          "name": "accountUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_accountUserId_user_id_fk": {
+          "name": "student_accountUserId_user_id_fk",
+          "tableFrom": "student",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accountUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag": {
+      "name": "tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_text_unique": {
+          "name": "tag_text_unique",
+          "columns": [
+            "text"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teacher_student": {
+      "name": "teacher_student",
+      "columns": {
+        "teacherId": {
+          "name": "teacherId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "studentId": {
+          "name": "studentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topicDagId": {
+          "name": "topicDagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teacher_student_teacherId_user_id_fk": {
+          "name": "teacher_student_teacherId_user_id_fk",
+          "tableFrom": "teacher_student",
+          "tableTo": "user",
+          "columnsFrom": [
+            "teacherId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teacher_student_studentId_student_id_fk": {
+          "name": "teacher_student_studentId_student_id_fk",
+          "tableFrom": "teacher_student",
+          "tableTo": "student",
+          "columnsFrom": [
+            "studentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teacher_student_topicDagId_topic_dag_id_fk": {
+          "name": "teacher_student_topicDagId_topic_dag_id_fk",
+          "tableFrom": "teacher_student",
+          "tableTo": "topic_dag",
+          "columnsFrom": [
+            "topicDagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teacher_student_teacherId_studentId_pk": {
+          "columns": [
+            "teacherId",
+            "studentId"
+          ],
+          "name": "teacher_student_teacherId_studentId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "topic_dag": {
+      "name": "topic_dag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tagEmbeddingStatus": {
+          "name": "tagEmbeddingStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "tagEmbeddingsTotal": {
+          "name": "tagEmbeddingsTotal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tagEmbeddingsComplete": {
+          "name": "tagEmbeddingsComplete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "topic_dag_userId_user_id_fk": {
+          "name": "topic_dag_userId_user_id_fk",
+          "tableFrom": "topic_dag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "uploaded_work": {
+      "name": "uploaded_work",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "studentId": {
+          "name": "studentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dateUploaded": {
+          "name": "dateUploaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dateCompleted": {
+          "name": "dateCompleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embeddings": {
+          "name": "embeddings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "originalDocument": {
+          "name": "originalDocument",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "originalFilename": {
+          "name": "originalFilename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "originalMimeType": {
+          "name": "originalMimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnailMimeType": {
+          "name": "thumbnailMimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "uploaded_work_userId_user_id_fk": {
+          "name": "uploaded_work_userId_user_id_fk",
+          "tableFrom": "uploaded_work",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploaded_work_studentId_student_id_fk": {
+          "name": "uploaded_work_studentId_student_id_fk",
+          "tableFrom": "uploaded_work",
+          "tableTo": "student",
+          "columnsFrom": [
+            "studentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verificationToken": {
+      "name": "verificationToken",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "columns": [
+            "identifier",
+            "token"
+          ],
+          "name": "verificationToken_identifier_token_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -57,5 +57,13 @@
       "when": 1752016946553,
       "tag": "0007_slippery_jetstream",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1752022063902,
+      "tag": "0008_crazy_rhodey",
+      "breakpoints": true
     }
-  ]}
+  ]
+}

--- a/app/src/components/UploadForm.test.tsx
+++ b/app/src/components/UploadForm.test.tsx
@@ -11,7 +11,7 @@ describe('UploadForm', () => {
       .mockResolvedValue({ ok: true, json: async () => ({ students: [] }) }) as unknown as typeof fetch
     render(<UploadForm />)
     fireEvent.submit(screen.getByRole('button'))
-    expect(await screen.findByText('File is required')).toBeInTheDocument()
+    expect(await screen.findByText('File or note required')).toBeInTheDocument()
     expect(await screen.findByText('Student ID is required')).toBeInTheDocument()
   })
 

--- a/app/src/components/UploadForm.tsx
+++ b/app/src/components/UploadForm.tsx
@@ -36,7 +36,10 @@ export function UploadForm({ onUploadStart, onSuccess, onError }: Props) {
   const onSubmit = async (data: UploadWorkClient) => {
     onUploadStart?.()
     const formData = new FormData()
-    formData.append('file', data.file[0])
+    if (data.file && data.file.length > 0) {
+      formData.append('file', data.file[0])
+    }
+    if (data.note) formData.append('note', data.note)
     if (data.dateCompleted) {
       formData.append('dateCompleted', data.dateCompleted.toISOString())
     }
@@ -57,6 +60,7 @@ export function UploadForm({ onUploadStart, onSuccess, onError }: Props) {
       className={css({ display: 'flex', flexDir: 'column', gap: '2', padding: '4' })}
     >
       <input type="file" data-testid="file" {...register('file')} />
+      <textarea placeholder={t('note')} {...register('note')} />
       {errors.file && <span>{errors.file.message}</span>}
       <input type="date" {...register('dateCompleted')} />
       <select {...register('studentId')} defaultValue="">

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -108,6 +108,7 @@ export const uploadedWork = sqliteTable('uploaded_work', {
     .$defaultFn(() => new Date()),
   dateCompleted: integer('dateCompleted', { mode: 'timestamp_ms' }),
   summary: text('summary'),
+  note: text('note'),
   embeddings: text('embeddings'),
   originalDocument: blob('originalDocument', { mode: 'buffer' }),
   originalFilename: text('originalFilename'),

--- a/app/src/forms/uploadWork.ts
+++ b/app/src/forms/uploadWork.ts
@@ -9,17 +9,26 @@ export const uploadWorkFieldsSchema = z.object({
   studentId: z.string().min(1, 'Student ID is required'),
   dateCompleted: z
     .preprocess((v) => (v ? new Date(String(v)) : undefined), z.date().optional()),
+  note: z.string().optional(),
 })
 
-export const uploadWorkServerSchema = uploadWorkFieldsSchema.extend({
-  file: z.instanceof(File, { message: 'File is required' }),
-})
+export const uploadWorkServerSchema = uploadWorkFieldsSchema
+  .extend({
+    file: z.instanceof(File).optional(),
+  })
+  .refine((v) => v.file instanceof File || (v.note && v.note.trim().length > 0), {
+    message: 'File or note required',
+    path: ['file'],
+  })
 
-export const uploadWorkClientSchema = uploadWorkFieldsSchema.extend({
-  file: z
-    .instanceof(FileListType)
-    .refine((list) => list.length > 0, 'File is required'),
-})
+export const uploadWorkClientSchema = uploadWorkFieldsSchema
+  .extend({
+    file: z.instanceof(FileListType).optional(),
+  })
+  .refine((v) =>
+    (v.file && (v.file as FileList).length > 0) || (v.note && v.note.trim().length > 0),
+    { message: 'File or note required', path: ['file'] }
+  )
 
 export type UploadWorkFields = z.infer<typeof uploadWorkFieldsSchema>
 export type UploadWorkServer = z.infer<typeof uploadWorkServerSchema>

--- a/app/src/locales/en/common.json
+++ b/app/src/locales/en/common.json
@@ -24,6 +24,7 @@
   "save": "Save",
   "name": "Name",
   "email": "Email",
+  "note": "Note",
   "add": "Add",
   "student": "Student",
   "groupBy": "Group by",

--- a/app/src/locales/es/common.json
+++ b/app/src/locales/es/common.json
@@ -24,6 +24,7 @@
   "save": "Guardar",
   "name": "Nombre",
   "email": "Correo electrónico",
+  "note": "Nota",
   "add": "Agregar",
   "student": "Estudiante",
   "groupBy": "Agrupar por",

--- a/app/src/locales/fr/common.json
+++ b/app/src/locales/fr/common.json
@@ -24,6 +24,7 @@
   "save": "Enregistrer",
   "name": "Nom",
   "email": "E-mail",
+  "note": "Note",
   "add": "Ajouter",
   "student": "Étudiant",
   "groupBy": "Grouper par",

--- a/app/tests/e2e/uploadWork.test.ts
+++ b/app/tests/e2e/uploadWork.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/db', () => {
   const where = vi
     .fn()
     .mockResolvedValueOnce([{ teacherId: 'u1', studentId: '1' }])
+    .mockResolvedValueOnce([{ teacherId: 'u1', studentId: '1' }])
     .mockResolvedValue([]);
   const from = vi.fn(() => ({ where }));
   const select = vi.fn(() => ({ from }));
@@ -44,6 +45,16 @@ describe('upload-work API', () => {
     form.set('file', new File(['hello'], 'hello.txt'));
     form.set('studentId', '1');
     form.set('dateCompleted', '2024-01-01');
+    const req = new NextRequest(new Request('http://localhost/api/upload-work', { method: 'POST', body: form }));
+    const res = await uploadWork(req);
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts note without file', async () => {
+    (getServerSession as unknown as Mock).mockResolvedValue({ user: { id: 'u1' } });
+    const form = new FormData();
+    form.set('note', 'hello note');
+    form.set('studentId', '1');
     const req = new NextRequest(new Request('http://localhost/api/upload-work', { method: 'POST', body: form }));
     const res = await uploadWork(req);
     expect(res.status).toBe(200);

--- a/docs/usage/uploaded_work.md
+++ b/docs/usage/uploaded_work.md
@@ -1,6 +1,6 @@
 # Uploaded Work
 
-Authenticated users can upload documents from the **Uploaded Work** page. The server stores the original file, an LLM-generated summary and timestamps for when the work was completed and uploaded. Embedding vectors are generated with the `multimodal-embedding-3-small` model and indexed using **sqlite-vec** for fast similarity search.
+Authenticated users can upload documents or write free text notes from the **Uploaded Work** page. The server stores the original file when provided, an LLM-generated summary (or the note text) and timestamps for when the work was completed and uploaded. Embedding vectors are generated with the `multimodal-embedding-3-small` model and indexed using **sqlite-vec** for fast similarity search.
 
 Each upload appears in the list with its summary for easy review. New uploads show a temporary `Processing...` placeholder while the summary is generated. Any errors are shown next to the list.
 


### PR DESCRIPTION
## Summary
- add `note` column to `uploaded_work`
- update forms and API to support uploading notes without files
- tweak validations and tests
- document free text notes

## Testing
- `pnpm -F app run lint`
- `pnpm -F app run typecheck`
- `pnpm -F app test`
- `pnpm -F app test:e2e`
- `pnpm -F app build`


------
https://chatgpt.com/codex/tasks/task_e_686dbb75ec38832b89da1f4a3e6dd50d