### PR TITLE
Fix student curriculum selection

### DIFF
--- a/app/src/components/StudentCurriculum.test.tsx
+++ b/app/src/components/StudentCurriculum.test.tsx
@@ -1,11 +1,13 @@
 vi.mock('react-mermaid2', () => ({ default: () => <div data-testid="mermaid" /> }))
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { StudentCurriculum } from './StudentCurriculum'
 import I18nProvider from './I18nProvider'
 import type { Mock } from 'vitest'
 
 vi.stubGlobal('fetch', vi.fn())
 const mockFetch = fetch as unknown as Mock
+const user = userEvent.setup()
 
 function mockStudent(topicDagId: string | null) {
   mockFetch.mockResolvedValueOnce({
@@ -53,5 +55,18 @@ describe('StudentCurriculum', () => {
       </I18nProvider>
     )
     expect(await screen.findByText('A, B')).toBeInTheDocument()
+  })
+
+  it('allows changing curriculum', async () => {
+    mockStudent('d1')
+    mockDags()
+    render(
+      <I18nProvider lng="en">
+        <StudentCurriculum studentId="s1" />
+      </I18nProvider>
+    )
+    expect(await screen.findByText('A, B')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Change curriculum' }))
+    expect(await screen.findByRole('button', { name: 'Save' })).toBeDisabled()
   })
 })

--- a/app/src/components/StudentCurriculum.tsx
+++ b/app/src/components/StudentCurriculum.tsx
@@ -21,6 +21,7 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
   const [data, setData] = useState<StudentData | null>(null)
   const [dags, setDags] = useState<Dag[]>([])
   const [selected, setSelected] = useState('')
+  const [editing, setEditing] = useState(false)
   const { t } = useTranslation()
 
   const load = async () => {
@@ -57,6 +58,7 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ topicDagId: selected }),
     })
+    setEditing(false)
     load()
   }
 
@@ -68,7 +70,7 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
 
   if (!data) return null
 
-  if (!data.topicDagId) {
+  if (!data.topicDagId || editing) {
     return (
       <div style={{ marginBottom: '1rem' }}>
         <label>
@@ -88,6 +90,17 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
         <button onClick={save} disabled={!selected} style={{ marginLeft: '0.5rem' }}>
           {t('save')}
         </button>
+        {data.topicDagId && (
+          <button
+            onClick={() => {
+              setEditing(false)
+              setSelected(data.topicDagId || '')
+            }}
+            style={{ marginLeft: '0.5rem' }}
+          >
+            {t('cancel')}
+          </button>
+        )}
       </div>
     )
   }
@@ -101,6 +114,16 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
           <Mermaid chart={graphToMermaid(data.graph)} />
         </div>
       )}
+      <div style={{ marginTop: '0.5rem' }}>
+        <button
+          onClick={() => {
+            setSelected('')
+            setEditing(true)
+          }}
+        >
+          {t('change')}
+        </button>
+      </div>
     </div>
   )
 }

--- a/app/src/locales/en/common.json
+++ b/app/src/locales/en/common.json
@@ -50,5 +50,7 @@
   "generatingGraph": "Generating graph...",
   "failedGenerateGraph": "Failed to generate graph: {{error}}. Please try again later.",
   "saveGraph": "Save Graph",
-  "saved": "Saved"
+  "saved": "Saved",
+  "cancel": "Cancel",
+  "change": "Change curriculum"
 }

--- a/app/src/locales/es/common.json
+++ b/app/src/locales/es/common.json
@@ -50,5 +50,7 @@
   "generatingGraph": "Generando gráfico...",
   "failedGenerateGraph": "Error al generar el gráfico: {{error}}. Inténtalo de nuevo más tarde.",
   "saveGraph": "Guardar gráfico",
-  "saved": "Guardado"
+  "saved": "Guardado",
+  "cancel": "Cancelar",
+  "change": "Cambiar currículo"
 }

--- a/app/src/locales/fr/common.json
+++ b/app/src/locales/fr/common.json
@@ -50,5 +50,7 @@
   "generatingGraph": "Génération du graphique...",
   "failedGenerateGraph": "Échec de la génération du graphique : {{error}}. Veuillez réessayer plus tard.",
   "saveGraph": "Enregistrer le graphique",
-  "saved": "Enregistré"
+  "saved": "Enregistré",
+  "cancel": "Annuler",
+  "change": "Modifier le curriculum"
 }


### PR DESCRIPTION
## Summary
- allow editing student curriculum after initial selection
- translate new 'cancel' and 'change curriculum' labels
- update StudentCurriculum tests for new behavior

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686dc3138208832bb2e125270ec0d3f8