### PR TITLE
Show curriculum tags on graph nodes

### DIFF
--- a/app/src/components/CurriculumGraph.stories.tsx
+++ b/app/src/components/CurriculumGraph.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta } from '@storybook/react'
+import { CurriculumGraph } from './CurriculumGraph'
+
+const meta: Meta<typeof CurriculumGraph> = {
+  title: 'CurriculumGraph',
+  component: CurriculumGraph,
+}
+export default meta
+
+export const Default = {
+  args: {
+    graph: {
+      nodes: [
+        { id: 'a', label: 'A', desc: '', tags: ['tag1', 'tag2'], grade: undefined },
+        { id: 'b', label: 'B', desc: '', tags: ['tag3'], grade: undefined },
+      ],
+      edges: [['a', 'b']],
+    },
+  },
+}

--- a/app/src/components/CurriculumGraph.test.tsx
+++ b/app/src/components/CurriculumGraph.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CurriculumGraph } from './CurriculumGraph'
+import type { Graph } from '@/graphSchema'
+
+vi.mock('react-mermaid2', () => ({
+  default: () => (
+    <svg data-testid="mermaid">
+      <g id="a"><rect width="40" height="20" /></g>
+    </svg>
+  ),
+}))
+
+vi.mock('@/graphToMermaid', () => ({ graphToMermaid: () => 'graph' }))
+
+function rect(x: number, y: number, w: number, h: number) {
+  return { x, y, width: w, height: h, top: y, left: x, right: x + w, bottom: y + h, toJSON: () => '' }
+}
+
+describe('CurriculumGraph', () => {
+  it('shows tags on hover', async () => {
+    const graph: Graph = { nodes: [{ id: 'a', label: 'A', desc: '', tags: ['t1','t2'], prereq: [], grade: undefined }], edges: [] }
+    const { container } = render(<CurriculumGraph graph={graph} />)
+    const g = container.querySelector('g#a') as SVGGraphicsElement
+    const svg = container.querySelector('svg') as SVGSVGElement
+    g.getBoundingClientRect = () => rect(0, 0, 40, 20)
+    svg.getBoundingClientRect = () => rect(0, 0, 40, 20)
+    await new Promise((r) => setTimeout(r))
+    await userEvent.hover(container.querySelector('div[style]') as HTMLElement)
+    expect((await screen.findAllByText('t1, t2')).length).toBeGreaterThan(0)
+  })
+})

--- a/app/src/components/CurriculumGraph.tsx
+++ b/app/src/components/CurriculumGraph.tsx
@@ -1,0 +1,59 @@
+'use client'
+import { useEffect, useRef, useState } from 'react'
+import Mermaid from 'react-mermaid2'
+import { css } from '@/styled-system/css'
+import { graphToMermaid } from '@/graphToMermaid'
+import type { Graph } from '@/graphSchema'
+import { Tooltip } from './Tooltip'
+
+type Overlay = { id: string; tags: string[]; left: number; top: number; width: number; height: number }
+
+function getRects(container: HTMLDivElement, graph: Graph): Overlay[] {
+  const svg = container.querySelector('svg')
+  if (!svg) return []
+  const containerRect = container.getBoundingClientRect()
+  return graph.nodes.map((n) => {
+    const el = svg.querySelector<SVGGElement>(`#${n.id}`)
+    if (!el) return null
+    const r = el.getBoundingClientRect()
+    return {
+      id: n.id,
+      tags: n.tags,
+      left: r.left - containerRect.left,
+      top: r.top - containerRect.top,
+      width: r.width,
+      height: r.height,
+    }
+  }).filter(Boolean) as Overlay[]
+}
+
+export function CurriculumGraph({ graph }: { graph: Graph }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [overlays, setOverlays] = useState<Overlay[]>([])
+
+  useEffect(() => {
+    const container = ref.current
+    if (!container) return
+    const update = () => setOverlays(getRects(container, graph))
+    const id = setTimeout(update, 0)
+    window.addEventListener('resize', update)
+    return () => {
+      clearTimeout(id)
+      window.removeEventListener('resize', update)
+    }
+  }, [graph])
+
+  return (
+    <div ref={ref} className={css({ position: 'relative' })}>
+      <Mermaid chart={graphToMermaid(graph)} />
+      {overlays.map((o) => (
+        <Tooltip key={o.id} content={o.tags.join(', ')}>
+          <div
+            className={css({ position: 'absolute', bg: 'transparent' })}
+            style={{ left: o.left, top: o.top, width: o.width, height: o.height }}
+          />
+        </Tooltip>
+      ))}
+    </div>
+  )
+}

--- a/app/src/components/StudentCurriculum.tsx
+++ b/app/src/components/StudentCurriculum.tsx
@@ -1,9 +1,8 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Mermaid from 'react-mermaid2'
 import { Graph } from '@/graphSchema'
-import { graphToMermaid } from '@/graphToMermaid'
+import { CurriculumGraph } from './CurriculumGraph'
 
 interface Dag {
   id: string
@@ -98,7 +97,7 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
       <div>{data.topics.join(', ')}</div>
       {data.graph && (
         <div style={{ marginTop: '1rem' }}>
-          <Mermaid chart={graphToMermaid(data.graph)} />
+          <CurriculumGraph graph={data.graph} />
         </div>
       )}
     </div>

--- a/app/src/components/TopicDAGList.tsx
+++ b/app/src/components/TopicDAGList.tsx
@@ -1,8 +1,7 @@
 'use client'
 import { useEffect, useState, useRef } from 'react'
-import Mermaid from 'react-mermaid2'
 import { Graph } from '@/graphSchema'
-import { graphToMermaid } from '@/graphToMermaid'
+import { CurriculumGraph } from './CurriculumGraph'
 
 interface Dag {
   id: string
@@ -63,7 +62,7 @@ export function TopicDAGList() {
           </div>
           {expanded === d.id && (
             <div style={{ marginTop: '1rem' }}>
-              <Mermaid chart={graphToMermaid(d.graph)} />
+              <CurriculumGraph graph={d.graph} />
             </div>
           )}
         </li>


### PR DESCRIPTION
## Summary
- overlay tooltips on flowchart nodes
- render graphs with tooltips on Student Curriculum and Curriculums pages
- test CurriculumGraph component
- document CurriculumGraph in Storybook

## Testing
- `pnpm --dir app run lint`
- `pnpm --dir app run typecheck`
- `pnpm --dir app test`
- `pnpm --dir app test:e2e`
- `pnpm --dir app build`


------
https://chatgpt.com/codex/tasks/task_e_686dc346e3a8832b8bf3f05a747bcc1d