### PR TITLE
Show tags on graph nodes

### DIFF
--- a/app/src/components/StudentCurriculum.tsx
+++ b/app/src/components/StudentCurriculum.tsx
@@ -66,6 +66,20 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [studentId])
 
+  useEffect(() => {
+    if (!data?.graph) return
+    for (const node of data.graph.nodes) {
+      const el =
+        document.getElementById(node.id) ||
+        document.getElementById(`flowchart-${node.id}`)
+      if (el && !el.querySelector('title')) {
+        const title = document.createElement('title')
+        title.textContent = node.tags.join(', ')
+        el.appendChild(title)
+      }
+    }
+  }, [data?.graph])
+
   if (!data) return null
 
   if (!data.topicDagId) {

--- a/app/src/components/TopicDAGList.tsx
+++ b/app/src/components/TopicDAGList.tsx
@@ -44,6 +44,21 @@ export function TopicDAGList() {
     }
   }, [])
 
+  useEffect(() => {
+    const dag = dags.find((d) => d.id === expanded)
+    if (!dag) return
+    for (const node of dag.graph.nodes) {
+      const el =
+        document.getElementById(node.id) ||
+        document.getElementById(`flowchart-${node.id}`)
+      if (el && !el.querySelector('title')) {
+        const title = document.createElement('title')
+        title.textContent = node.tags.join(', ')
+        el.appendChild(title)
+      }
+    }
+  }, [expanded, dags])
+
   return (
     <ul>
       {dags.map((d) => (


### PR DESCRIPTION
## Summary
- add node tag titles to student curriculum and topic dag graphs
- include these titles when graphs are expanded

## Testing
- `pnpm run lint`
- `pnpm run typecheck` *(fails: Cannot find module '@/styled-system/css' or its corresponding type declarations.)*
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686dc346e3a8832b8bf3f05a747bcc1d