### PR TITLE
Add DAG node tooltips

### DIFF
--- a/app/src/components/GraphWithTooltips.stories.tsx
+++ b/app/src/components/GraphWithTooltips.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta } from '@storybook/react'
+import { GraphWithTooltips } from './GraphWithTooltips'
+
+const meta: Meta<typeof GraphWithTooltips> = {
+  title: 'GraphWithTooltips',
+  component: GraphWithTooltips,
+}
+export default meta
+
+export const Default = {
+  args: {
+    graph: {
+      nodes: [
+        { id: 'a', label: 'A', desc: '', tags: ['alpha', 'beta', 'gamma'] },
+        { id: 'b', label: 'B', desc: '', tags: ['beta', 'delta', 'epsilon'] },
+      ],
+      edges: [['a', 'b']],
+    },
+  },
+}

--- a/app/src/components/GraphWithTooltips.test.tsx
+++ b/app/src/components/GraphWithTooltips.test.tsx
@@ -1,0 +1,13 @@
+vi.mock('react-mermaid2', () => ({ default: () => <div data-testid="mermaid" /> }))
+import { render, screen } from '@testing-library/react'
+import { GraphWithTooltips } from './GraphWithTooltips'
+import type { Graph } from '@/graphSchema'
+
+test('renders mermaid graph', () => {
+  const graph: Graph = {
+    nodes: [{ id: 'a', label: 'A', desc: '', prereq: [], tags: ['t1', 't2', 't3'] }],
+    edges: [],
+  }
+  render(<GraphWithTooltips graph={graph} />)
+  expect(screen.getByTestId('mermaid')).toBeInTheDocument()
+})

--- a/app/src/components/GraphWithTooltips.tsx
+++ b/app/src/components/GraphWithTooltips.tsx
@@ -1,0 +1,39 @@
+'use client'
+import { useEffect, useRef } from 'react'
+import { createRoot, Root } from 'react-dom/client'
+import Mermaid from 'react-mermaid2'
+import type { Graph } from '@/graphSchema'
+import { graphToMermaid } from '@/graphToMermaid'
+import { Tooltip } from './Tooltip'
+
+export function GraphWithTooltips({ graph }: { graph: Graph }) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const container = ref.current
+    if (!container) return
+    const spans = container.querySelectorAll<HTMLSpanElement>('.dag-node')
+    const roots: Root[] = []
+    spans.forEach((span) => {
+      const tags = span.dataset.tags
+      if (!tags) return
+      const text = span.textContent || ''
+      const root = createRoot(span)
+      roots.push(root)
+      root.render(
+        <Tooltip content={tags.split(', ').join(', ')}>
+          <span>{text}</span>
+        </Tooltip>
+      )
+    })
+    return () => {
+      roots.forEach((r) => r.unmount())
+    }
+  }, [graph])
+
+  return (
+    <div ref={ref}>
+      <Mermaid chart={graphToMermaid(graph, { htmlLabels: true })} config={{ securityLevel: 'loose' }} />
+    </div>
+  )
+}

--- a/app/src/components/StudentCurriculum.tsx
+++ b/app/src/components/StudentCurriculum.tsx
@@ -1,9 +1,8 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Mermaid from 'react-mermaid2'
 import { Graph } from '@/graphSchema'
-import { graphToMermaid } from '@/graphToMermaid'
+import { GraphWithTooltips } from './GraphWithTooltips'
 
 interface Dag {
   id: string
@@ -98,7 +97,7 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
       <div>{data.topics.join(', ')}</div>
       {data.graph && (
         <div style={{ marginTop: '1rem' }}>
-          <Mermaid chart={graphToMermaid(data.graph)} />
+          <GraphWithTooltips graph={data.graph} />
         </div>
       )}
     </div>

--- a/app/src/components/TopicDAGList.tsx
+++ b/app/src/components/TopicDAGList.tsx
@@ -1,8 +1,7 @@
 'use client'
 import { useEffect, useState, useRef } from 'react'
-import Mermaid from 'react-mermaid2'
 import { Graph } from '@/graphSchema'
-import { graphToMermaid } from '@/graphToMermaid'
+import { GraphWithTooltips } from './GraphWithTooltips'
 
 interface Dag {
   id: string
@@ -63,7 +62,7 @@ export function TopicDAGList() {
           </div>
           {expanded === d.id && (
             <div style={{ marginTop: '1rem' }}>
-              <Mermaid chart={graphToMermaid(d.graph)} />
+              <GraphWithTooltips graph={d.graph} />
             </div>
           )}
         </li>

--- a/app/src/graphToMermaid.ts
+++ b/app/src/graphToMermaid.ts
@@ -1,9 +1,24 @@
 import { Graph } from "./graphSchema";
 
-export function graphToMermaid(graph: Graph): string {
+export interface GraphToMermaidOptions {
+  /**
+   * When true each node label will include a span with data-tags for attaching
+   * tooltips. HTML labels require Mermaid's `securityLevel` to be `loose`.
+   */
+  htmlLabels?: boolean;
+}
+
+export function graphToMermaid(
+  graph: Graph,
+  options: GraphToMermaidOptions = {}
+): string {
   const lines = ["graph LR"];
   for (const node of graph.nodes) {
-    const label = node.label.replace(/"/g, '\\"');
+    let label = node.label.replace(/"/g, '\\"');
+    if (options.htmlLabels) {
+      const span = `<span class='dag-node' data-tags='${node.tags.join(", ")}'>${label}</span>`;
+      label = span.replace(/"/g, '\\"');
+    }
     lines.push(`  ${node.id}["${label}"]`);
   }
   for (const [from, to] of graph.edges) {

--- a/docs/usage/my_curriculums.md
+++ b/docs/usage/my_curriculums.md
@@ -3,3 +3,4 @@
 The **My Curriculums** page lists every topic graph you've generated and saved from the Curriculum Generator. Click a row to view the full graph. Each entry shows when it was created and which topics were included.
 
 When a curriculum is first saved the server extracts all node tags and embeds new ones in the background. The list displays the current progress as `Tag processing: X/Y` until complete.
+When viewing an expanded graph you can hover over any node to see its tags.

--- a/docs/usage/student_progress.md
+++ b/docs/usage/student_progress.md
@@ -1,3 +1,4 @@
 # Student Progress
 
 Click a student's name from the **Students** page to open their progress view. The top of the page shows the selected curriculum along with the topics and rendered DAG. If no curriculum is assigned you can pick one from your saved DAGs. Below the curriculum section all uploaded work for that student is listed using the same interface as the **Uploaded Work** page. Hover over a tag to see which DAG node it belongs to along with the node's immediate prerequisites and dependents.
+When looking at the graph itself you can hover over any node to view its tags.


### PR DESCRIPTION
## Summary
- show tags for graph nodes using new `GraphWithTooltips` component
- attach `GraphWithTooltips` on curriculum pages
- enable optional HTML labels via `graphToMermaid`
- document hovering graph nodes

## Testing
- `pnpm --dir app run lint`
- `pnpm --dir app run typecheck`
- `pnpm --dir app test`
- `pnpm --dir app test:e2e`
- `pnpm --dir app build`


------
https://chatgpt.com/codex/tasks/task_e_686dc346e3a8832b8bf3f05a747bcc1d