### PR TITLE
Add tag tooltips to curriculum nodes

### DIFF
--- a/app/src/components/CurriculumGraph.tsx
+++ b/app/src/components/CurriculumGraph.tsx
@@ -1,0 +1,38 @@
+'use client'
+import { useEffect, useRef } from 'react'
+import Mermaid from 'react-mermaid2'
+import { createRoot } from 'react-dom/client'
+import type { Graph } from '@/graphSchema'
+import { graphToMermaid } from '@/graphToMermaid'
+import { Tooltip } from './Tooltip'
+
+export function CurriculumGraph({ graph }: { graph: Graph }) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const container = ref.current
+    if (!container) return
+    const nodeMap = new Map(graph.nodes.map((n) => [n.id, n]))
+    const labels = container.querySelectorAll<HTMLSpanElement>('.node-label')
+    labels.forEach((el) => {
+      const id = el.dataset.nodeId
+      if (!id || el.dataset.tooltipMounted) return
+      const node = nodeMap.get(id)
+      if (!node) return
+      const root = createRoot(el)
+      root.render(
+        <Tooltip content={node.tags.join(', ')}>
+          <span>{node.label}</span>
+        </Tooltip>
+      )
+      el.dataset.tooltipMounted = 'true'
+    })
+  }, [graph])
+
+  return (
+    <div ref={ref}>
+      <Mermaid chart={graphToMermaid(graph)} />
+    </div>
+  )
+}
+

--- a/app/src/components/StudentCurriculum.tsx
+++ b/app/src/components/StudentCurriculum.tsx
@@ -1,9 +1,8 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Mermaid from 'react-mermaid2'
 import { Graph } from '@/graphSchema'
-import { graphToMermaid } from '@/graphToMermaid'
+import { CurriculumGraph } from './CurriculumGraph'
 
 interface Dag {
   id: string
@@ -98,7 +97,7 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
       <div>{data.topics.join(', ')}</div>
       {data.graph && (
         <div style={{ marginTop: '1rem' }}>
-          <Mermaid chart={graphToMermaid(data.graph)} />
+          <CurriculumGraph graph={data.graph} />
         </div>
       )}
     </div>

--- a/app/src/components/TopicDAGList.tsx
+++ b/app/src/components/TopicDAGList.tsx
@@ -1,8 +1,7 @@
 'use client'
 import { useEffect, useState, useRef } from 'react'
-import Mermaid from 'react-mermaid2'
 import { Graph } from '@/graphSchema'
-import { graphToMermaid } from '@/graphToMermaid'
+import { CurriculumGraph } from './CurriculumGraph'
 
 interface Dag {
   id: string
@@ -63,7 +62,7 @@ export function TopicDAGList() {
           </div>
           {expanded === d.id && (
             <div style={{ marginTop: '1rem' }}>
-              <Mermaid chart={graphToMermaid(d.graph)} />
+              <CurriculumGraph graph={d.graph} />
             </div>
           )}
         </li>

--- a/app/src/graphToMermaid.test.ts
+++ b/app/src/graphToMermaid.test.ts
@@ -14,8 +14,12 @@ describe('graphToMermaid', () => {
   it('converts graph to mermaid syntax', () => {
     const mermaid = graphToMermaid(graph);
     expect(mermaid).toContain('graph LR');
-    expect(mermaid).toContain('a["Node A"]');
-    expect(mermaid).toContain('b["Node \\\"B\\\""]');
+    expect(mermaid).toContain(
+      'a["<span class=\'node-label\' data-node-id=\'a\'>Node A</span>"]'
+    );
+    expect(mermaid).toContain(
+      'b["<span class=\'node-label\' data-node-id=\'b\'>Node &quot;B&quot;</span>"]'
+    );
     expect(mermaid).toContain('a --> b');
   });
 });

--- a/app/src/graphToMermaid.ts
+++ b/app/src/graphToMermaid.ts
@@ -1,10 +1,20 @@
 import { Graph } from "./graphSchema";
 
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
 export function graphToMermaid(graph: Graph): string {
   const lines = ["graph LR"];
   for (const node of graph.nodes) {
-    const label = node.label.replace(/"/g, '\\"');
-    lines.push(`  ${node.id}["${label}"]`);
+    const label = escapeHtml(node.label);
+    const html = `<span class='node-label' data-node-id='${node.id}'>${label}</span>`;
+    const escaped = html.replace(/"/g, '\\"');
+    lines.push(`  ${node.id}["${escaped}"]`);
   }
   for (const [from, to] of graph.edges) {
     lines.push(`  ${from} --> ${to}`);


### PR DESCRIPTION
## Summary
- extract tags for graph nodes into mermaid markup
- add `CurriculumGraph` component that mounts tooltips onto mermaid nodes
- show curriculum graph with tooltips in student and curriculum pages
- update `graphToMermaid` test to handle new markup

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686dc346e3a8832b8bf3f05a747bcc1d