### PR TITLE
Unify LLM work upload flow

### DIFF
--- a/app/drizzle/0009_eminent_marvel_apes.sql
+++ b/app/drizzle/0009_eminent_marvel_apes.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `uploaded_work` ADD `grade` text;--> statement-breakpoint
+ALTER TABLE `uploaded_work` ADD `extractedStudentName` text;--> statement-breakpoint
+ALTER TABLE `uploaded_work` ADD `extractedDateOfWork` text;--> statement-breakpoint
+ALTER TABLE `uploaded_work` ADD `masteryPercent` real;--> statement-breakpoint
+ALTER TABLE `uploaded_work` ADD `feedback` text;--> statement-breakpoint

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -64,6 +64,12 @@
       "when": 1752022063902,
       "tag": "0008_crazy_rhodey",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1752028889696,
+      "tag": "0009_eminent_marvel_apes",
+      "breakpoints": true
     }
-  ]
-}
+  ]}

--- a/app/src/app/api/upload-work/route.ts
+++ b/app/src/app/api/upload-work/route.ts
@@ -70,6 +70,11 @@ export async function POST(req: NextRequest) {
   }
 
   let summary = '';
+  let grade: string | null = null;
+  let extractedStudentName: string | null = null;
+  let extractedDateOfWork: string | null = null;
+  let masteryPercent: number | null = null;
+  let feedback: string | null = null;
   const summarySchema = z.object({
     summary: z.string(),
     grade: z.string().optional().nullable(),
@@ -104,6 +109,14 @@ export async function POST(req: NextRequest) {
       );
       if (!res.error && res.response) {
         summary = res.response.summary;
+        grade = res.response.grade ?? null;
+        extractedStudentName = res.response.studentName ?? null;
+        extractedDateOfWork = res.response.dateOfWork ?? null;
+        masteryPercent =
+          typeof res.response.masteryPercent === 'number'
+            ? res.response.masteryPercent
+            : null;
+        feedback = res.response.feedback ?? null;
       }
     }
   } catch (err) {
@@ -128,6 +141,11 @@ export async function POST(req: NextRequest) {
     dateUploaded: new Date(),
     dateCompleted: dateCompleted ? new Date(dateCompleted) : null,
     summary,
+    grade,
+    extractedStudentName,
+    extractedDateOfWork,
+    masteryPercent,
+    feedback,
     note: fields.note || null,
     originalDocument: buffer,
     originalFilename: file instanceof File ? file.name : null,

--- a/app/src/components/UploadForm.test.tsx
+++ b/app/src/components/UploadForm.test.tsx
@@ -16,7 +16,7 @@ describe('UploadForm', () => {
       </I18nProvider>
     )
     fireEvent.submit(await screen.findByRole('button'))
-    expect(await screen.findByText('File or note is required')).toBeInTheDocument()
+    expect(await screen.findByText('File is required')).toBeInTheDocument()
     expect(await screen.findByText('Student ID is required')).toBeInTheDocument()
   })
 

--- a/app/src/components/UploadedWorkList.tsx
+++ b/app/src/components/UploadedWorkList.tsx
@@ -17,6 +17,11 @@ interface Work {
   id: string
   studentId: string
   summary: string | null
+  grade: string | null
+  extractedStudentName: string | null
+  extractedDateOfWork: string | null
+  masteryPercent: number | null
+  feedback: string | null
   dateUploaded: string
   dateCompleted: string | null
   tags: Tag[]
@@ -170,6 +175,32 @@ export function UploadedWorkList({ studentId = '' }: { studentId?: string } = {}
                     {new Date(w.dateCompleted || w.dateUploaded).toDateString()}
                   </strong>
                   <SummaryWithMath text={w.summary ?? ''} />
+                  {w.grade && (
+                    <div>
+                      {t('grade')}: {w.grade}
+                    </div>
+                  )}
+                  {w.masteryPercent !== null && (
+                    <div>
+                      {t('masteryPercent')}: {w.masteryPercent}%
+                    </div>
+                  )}
+                  {w.extractedStudentName && (
+                    <div>
+                      {t('studentName')}: {w.extractedStudentName}
+                    </div>
+                  )}
+                  {w.extractedDateOfWork && (
+                    <div>
+                      {t('dateOfWork')}:{' '}
+                      {new Date(w.extractedDateOfWork).toDateString()}
+                    </div>
+                  )}
+                  {w.feedback && (
+                    <div>
+                      {t('feedback')}: {w.feedback}
+                    </div>
+                  )}
                   {w.tags.length > 0 && (
                     <div>
                       {w.tags.map((t) => (

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, primaryKey, blob } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, primaryKey, blob, real } from 'drizzle-orm/sqlite-core';
 import crypto from 'node:crypto';
 
 export const users = sqliteTable('user', {
@@ -108,6 +108,11 @@ export const uploadedWork = sqliteTable('uploaded_work', {
     .$defaultFn(() => new Date()),
   dateCompleted: integer('dateCompleted', { mode: 'timestamp_ms' }),
   summary: text('summary'),
+  grade: text('grade'),
+  extractedStudentName: text('extractedStudentName'),
+  extractedDateOfWork: text('extractedDateOfWork'),
+  masteryPercent: real('masteryPercent'),
+  feedback: text('feedback'),
   note: text('note'),
   embeddings: text('embeddings'),
   originalDocument: blob('originalDocument', { mode: 'buffer' }),

--- a/app/src/llm/client.test.ts
+++ b/app/src/llm/client.test.ts
@@ -56,4 +56,14 @@ describe('LLMClient', () => {
     expect(result.response).toBeNull();
     expect(mockCreate).toHaveBeenCalledTimes(1);
   });
+
+  test('chatMessages uses provided messages', async () => {
+    const schema = z.object({ msg: z.string() });
+    mockCreate.mockResolvedValue({ choices: [{ message: { content: '{"msg":"ok"}' } }] });
+    const client = new LLMClient('key');
+    const result = await client.chatMessages([{ role: 'user', content: 'hi' }], { schema, systemPrompt: 'sys' });
+    expect(result.error).toBeNull();
+    expect(result.response).toEqual({ msg: 'ok' });
+    expect(mockCreate).toHaveBeenCalled();
+  });
 });

--- a/app/src/locales/en/common.json
+++ b/app/src/locales/en/common.json
@@ -56,5 +56,10 @@
   "saveGraph": "Save Graph",
   "saved": "Saved",
   "cancel": "Cancel",
-  "change": "Change curriculum"
+  "change": "Change curriculum",
+  "grade": "Grade",
+  "masteryPercent": "Mastery",
+  "studentName": "Student Name",
+  "dateOfWork": "Date of Work",
+  "feedback": "Feedback"
 }

--- a/app/tests/e2e/uploadWork.test.ts
+++ b/app/tests/e2e/uploadWork.test.ts
@@ -6,8 +6,15 @@ import { getServerSession } from 'next-auth';
 vi.mock('next-auth', () => ({ getServerSession: vi.fn() }));
 vi.mock('openai', () => ({
   default: vi.fn().mockImplementation(() => ({
-    chat: { completions: { create: vi.fn().mockResolvedValue({ choices: [{ message: { content: 'sum' } }] }) } },
     embeddings: { create: vi.fn().mockResolvedValue({ data: [] }) }
+  }))
+}));
+vi.mock('@/llm/client', () => ({
+  LLMClient: vi.fn().mockImplementation(() => ({
+    chatMessages: vi.fn(async () => ({
+      error: null,
+      response: { summary: 'sum' }
+    }))
   }))
 }));
 vi.mock('@/authOptions', () => ({ authOptions: {} }));

--- a/docs/usage/uploaded_work.md
+++ b/docs/usage/uploaded_work.md
@@ -1,6 +1,6 @@
 # Uploaded Work
 
-Authenticated users can upload documents or write free text notes from the **Uploaded Work** page. The server stores the original file when provided, an LLM-generated summary (or the note text) and timestamps for when the work was completed and uploaded. Embedding vectors are generated with the `multimodal-embedding-3-small` model and indexed using **sqlite-vec** for fast similarity search.
+Authenticated users can upload documents or write free text notes from the **Uploaded Work** page. The server stores the original file when provided and asks the LLM to summarize the work. The response may also include an optional grade, extracted student name and date, an estimated percentage of topic mastery and short feedback. Embedding vectors are generated with the `multimodal-embedding-3-small` model and indexed using **sqlite-vec** for fast similarity search.
 
 Each upload appears in the list with its summary for easy review. New uploads show a temporary `Processing...` placeholder while the summary is generated. Any errors are shown next to the list.
 

--- a/docs/usage/uploaded_work.md
+++ b/docs/usage/uploaded_work.md
@@ -3,6 +3,7 @@
 Authenticated users can upload documents or write free text notes from the **Uploaded Work** page. The server stores the original file when provided and asks the LLM to summarize the work. The response may also include an optional grade, extracted student name and date, an estimated percentage of topic mastery and short feedback. Embedding vectors are generated with the `multimodal-embedding-3-small` model and indexed using **sqlite-vec** for fast similarity search.
 
 Each upload appears in the list with its summary for easy review. New uploads show a temporary `Processing...` placeholder while the summary is generated. Any errors are shown next to the list.
+If available, the grade, extracted student name and date, mastery percentage and feedback also display under each summary.
 
 Image uploads also generate a thumbnail shown to the left of the summary. Thumbnails are sized to at most 1.5 inches on each side while preserving aspect ratio.
 


### PR DESCRIPTION
## Summary
- add `chatMessages` method to `LLMClient`
- use `LLMClient` when summarizing uploaded work
- adjust UploadForm test expectations
- update e2e tests to mock the new LLM client
- add tests for `chatMessages`
- document new metadata returned from work uploads

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_686dd01d8568832bb26e086f1a25522c