### PR TITLE
Handle PDF uploads with thumbnails

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -48,6 +48,7 @@
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "sharp": "^0.34.2",
+    "pdfjs-dist": "^4.1.63",
     "sqlite-vec": "0.1.7-alpha.2",
     "sqlite3": "^5.1.7",
     "zod": "^3.25.74",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       openai:
         specifier: ^5.8.2
         version: 5.8.2(ws@8.18.3)(zod@3.25.74)
+      pdfjs-dist:
+        specifier: ^4.1.63
+        version: 4.10.38
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -1724,6 +1727,70 @@ packages:
   '@mrmlnc/readdir-enhanced@2.2.1':
     resolution: {integrity: sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==}
     engines: {node: '>=4'}
+
+  '@napi-rs/canvas-android-arm64@0.1.73':
+    resolution: {integrity: sha512-s8dMhfYIHVv7gz8BXg3Nb6cFi950Y0xH5R/sotNZzUVvU9EVqHfkqiGJ4UIqu+15UhqguT6mI3Bv1mhpRkmMQw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.73':
+    resolution: {integrity: sha512-bLPCq8Yyq1vMdVdIpQAqmgf6VGUknk8e7NdSZXJJFOA9gxkJ1RGcHOwoXo7h0gzhHxSorg71hIxyxtwXpq10Rw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.73':
+    resolution: {integrity: sha512-GR1CcehDjdNYXN3bj8PIXcXfYLUUOQANjQpM+KNnmpRo7ojsuqPjT7ZVH+6zoG/aqRJWhiSo+ChQMRazZlRU9g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.73':
+    resolution: {integrity: sha512-cM7F0kBJVFio0+U2iKSW4fWSfYQ8CPg4/DRZodSum/GcIyfB8+UPJSRM1BvvlcWinKLfX1zUYOwonZX9IFRRcw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.73':
+    resolution: {integrity: sha512-PMWNrMON9uz9klz1B8ZY/RXepQSC5dxxHQTowfw93Tb3fLtWO5oNX2k9utw7OM4ypT9BUZUWJnDQ5bfuXc/EUQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.73':
+    resolution: {integrity: sha512-lX0z2bNmnk1PGZ+0a9OZwI2lPPvWjRYzPqvEitXX7lspyLFrOzh2kcQiLL7bhyODN23QvfriqwYqp5GreSzVvA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.73':
+    resolution: {integrity: sha512-QDQgMElwxAoADsSR3UYvdTTQk5XOyD9J5kq15Z8XpGwpZOZsSE0zZ/X1JaOtS2x+HEZL6z1S6MF/1uhZFZb5ig==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.73':
+    resolution: {integrity: sha512-wbzLJrTalQrpyrU1YRrO6w6pdr5vcebbJa+Aut5QfTaW9eEmMb1WFG6l1V+cCa5LdHmRr8bsvl0nJDU/IYDsmw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.73':
+    resolution: {integrity: sha512-xbfhYrUufoTAKvsEx2ZUN4jvACabIF0h1F5Ik1Rk4e/kQq6c+Dwa5QF0bGrfLhceLpzHT0pCMGMDeQKQrcUIyA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.73':
+    resolution: {integrity: sha512-YQmHXBufFBdWqhx+ympeTPkMfs3RNxaOgWm59vyjpsub7Us07BwCcmu1N5kildhO8Fm0syoI2kHnzGkJBLSvsg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.73':
+    resolution: {integrity: sha512-9iwPZrNlCK4rG+vWyDvyvGeYjck9MoP0NVQP6N60gqJNFA1GsN0imG05pzNsqfCvFxUxgiTYlR8ff0HC1HXJiw==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@0.2.11':
     resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
@@ -7706,6 +7773,10 @@ packages:
     resolution: {integrity: sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==}
     engines: {node: '>=0.12'}
 
+  pdfjs-dist@4.10.38:
+    resolution: {integrity: sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==}
+    engines: {node: '>=20'}
+
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
@@ -12329,6 +12400,50 @@ snapshots:
     dependencies:
       call-me-maybe: 1.0.2
       glob-to-regexp: 0.3.0
+
+  '@napi-rs/canvas-android-arm64@0.1.73':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.73':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.73':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.73':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.73':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.73':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.73':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.73':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.73':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.73':
+    optional: true
+
+  '@napi-rs/canvas@0.1.73':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.73
+      '@napi-rs/canvas-darwin-arm64': 0.1.73
+      '@napi-rs/canvas-darwin-x64': 0.1.73
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.73
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.73
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.73
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.73
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.73
+      '@napi-rs/canvas-linux-x64-musl': 0.1.73
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.73
+    optional: true
 
   '@napi-rs/wasm-runtime@0.2.11':
     dependencies:
@@ -19736,6 +19851,10 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
       to-buffer: 1.2.1
+
+  pdfjs-dist@4.10.38:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.73
 
   perfect-debounce@1.0.0: {}
 

--- a/app/src/app/api/upload-work/route.ts
+++ b/app/src/app/api/upload-work/route.ts
@@ -15,7 +15,12 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/authOptions';
 import OpenAI from 'openai';
 import sharp from 'sharp';
+import { promises as fs } from 'node:fs';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { uploadWorkFieldsSchema, uploadWorkServerSchema } from '@/forms/uploadWork';
+
+const execFileP = promisify(execFile);
 
 export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -52,6 +57,7 @@ export async function POST(req: NextRequest) {
   let thumbnail: Buffer | null = null;
   const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || '' });
   const isImage = file instanceof File && file.type.startsWith('image/');
+  const isPdf = file instanceof File && file.type === 'application/pdf';
   if (file instanceof File) {
     buffer = Buffer.from(await file.arrayBuffer());
   }
@@ -63,6 +69,26 @@ export async function POST(req: NextRequest) {
         .toBuffer();
     } catch (err) {
       console.error('thumbnail error', err);
+    }
+  } else if (isPdf && buffer) {
+    const tmpBase = `/tmp/${crypto.randomUUID()}`;
+    const pdfPath = `${tmpBase}.pdf`;
+    const imgPath = `${tmpBase}.png`;
+    try {
+      await fs.writeFile(pdfPath, buffer);
+      await execFileP('pdftoppm', ['-png', '-singlefile', '-f', '1', '-l', '1', pdfPath, tmpBase]);
+      const png = await fs.readFile(imgPath);
+      const svg = `<svg width="144" height="144"><rect width="100%" height="100%" fill="rgba(0,0,0,0.3)"/><text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="48" font-weight="bold" fill="white">PDF</text></svg>`;
+      thumbnail = await sharp(png)
+        .resize({ width: 144, height: 144, fit: 'contain', background: 'white' })
+        .composite([{ input: Buffer.from(svg) }])
+        .png()
+        .toBuffer();
+    } catch (err) {
+      console.error('pdf thumbnail error', err);
+    } finally {
+      try { await fs.unlink(pdfPath); } catch {}
+      try { await fs.unlink(imgPath); } catch {}
     }
   }
 
@@ -81,6 +107,21 @@ export async function POST(req: NextRequest) {
         summary = chat.choices[0].message.content || '';
       } catch (err) {
         console.error('summary error', err);
+      }
+    } else if (isPdf && buffer) {
+      const tmpPdf = `/tmp/${crypto.randomUUID()}.pdf`;
+      try {
+        await fs.writeFile(tmpPdf, buffer);
+        const { stdout } = await execFileP('pdftotext', ['-q', tmpPdf, '-']);
+        const chat = await openai.chat.completions.create({
+          model: 'gpt-4o',
+          messages: [{ role: 'user', content: `Summarize this work: ${stdout}` }],
+        });
+        summary = chat.choices[0].message.content || '';
+      } catch (err) {
+        console.error('summary error', err);
+      } finally {
+        try { await fs.unlink(tmpPdf); } catch {}
       }
     } else if (buffer) {
       const text = buffer.toString('utf-8');

--- a/app/src/components/UploadForm.test.tsx
+++ b/app/src/components/UploadForm.test.tsx
@@ -16,7 +16,7 @@ describe('UploadForm', () => {
       </I18nProvider>
     )
     fireEvent.submit(await screen.findByRole('button'))
-    expect(await screen.findByText('File or note is required')).toBeInTheDocument()
+    expect(await screen.findByText('File is required')).toBeInTheDocument()
     expect(await screen.findByText('Student ID is required')).toBeInTheDocument()
   })
 

--- a/docs/usage/uploaded_work.md
+++ b/docs/usage/uploaded_work.md
@@ -4,7 +4,7 @@ Authenticated users can upload documents or write free text notes from the **Upl
 
 Each upload appears in the list with its summary for easy review. New uploads show a temporary `Processing...` placeholder while the summary is generated. Any errors are shown next to the list.
 
-Image uploads also generate a thumbnail shown to the left of the summary. Thumbnails are sized to at most 1.5 inches on each side while preserving aspect ratio.
+Image uploads generate a thumbnail shown to the left of the summary. PDF uploads are treated the same way—the first page is rasterized and "PDF" is overlaid on top. Thumbnails are sized to at most 1.5 inches on each side while preserving aspect ratio.
 
 If no thumbnail is available or a file type isn't supported, a placeholder icon displays the file's extension instead.
 


### PR DESCRIPTION
## Summary
- support PDF uploads in the work upload API
- create thumbnail from first page using `pdftoppm`
- overlay `PDF` text on generated thumbnail
- document PDF thumbnail behaviour
- fix UploadForm test expectations
- add `pdfjs-dist` dependency
- fix PDF thumbnail error by resizing with `'contain'`

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run panda`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_686dc8de5eec832badc1262991a39b52