### PR TITLE
Fix PDF summarization

### DIFF
--- a/app/src/app/api/upload-work/route.ts
+++ b/app/src/app/api/upload-work/route.ts
@@ -57,6 +57,8 @@ export async function POST(req: NextRequest) {
   uploadWorkServerSchema.parse({ ...fields, file: file instanceof File ? file : undefined });
   let buffer: Buffer | null = null;
   let thumbnail: Buffer | null = null;
+  let pdfImage: Buffer | null = null;
+  let pdfText = '';
   const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || '' });
   const llm = new LLMClient(process.env.OPENAI_API_KEY || '');
   const isImage = file instanceof File && file.type.startsWith('image/');
@@ -80,7 +82,10 @@ export async function POST(req: NextRequest) {
     try {
       await fs.writeFile(pdfPath, buffer);
       await execFileP('pdftoppm', ['-png', '-singlefile', '-f', '1', '-l', '1', pdfPath, tmpBase]);
-      const png = await fs.readFile(imgPath);
+      pdfImage = await fs.readFile(imgPath);
+      const { stdout } = await execFileP('pdftotext', ['-q', pdfPath, '-']);
+      pdfText = stdout;
+      const png = pdfImage;
       const svg = `<svg width="144" height="144"><rect width="100%" height="100%" fill="rgba(0,0,0,0.3)"/><text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="48" font-weight="bold" fill="white">PDF</text></svg>`;
       thumbnail = await sharp(png)
         .resize({ width: 144, height: 144, fit: 'contain', background: 'white' })
@@ -115,9 +120,16 @@ export async function POST(req: NextRequest) {
     parts.push({ type: 'text', text: fields.note });
   }
   if (file instanceof File && buffer) {
-    if (isImage || isPdf) {
+    if (isImage) {
       const base64 = buffer.toString('base64');
       parts.push({ type: 'image_url', image_url: { url: `data:${file.type};base64,${base64}` } });
+    } else if (isPdf) {
+      if (pdfImage) {
+        parts.push({ type: 'image_url', image_url: { url: `data:image/png;base64,${pdfImage.toString('base64')}` } });
+      }
+      if (pdfText) {
+        parts.push({ type: 'text', text: pdfText });
+      }
     } else {
       const text = buffer.toString('utf-8');
       parts.push({ type: 'text', text });

--- a/docs/usage/uploaded_work.md
+++ b/docs/usage/uploaded_work.md
@@ -1,6 +1,7 @@
 # Uploaded Work
 
 Authenticated users can upload documents or write free text notes from the **Uploaded Work** page. The server stores the original file when provided and asks the LLM to summarize the work. The response may also include an optional grade, extracted student name and date, an estimated percentage of topic mastery and short feedback. Embedding vectors are generated with the `multimodal-embedding-3-small` model and indexed using **sqlite-vec** for fast similarity search.
+For PDF uploads the text content is extracted for analysis and the first page is also sent to the LLM as an image.
 
 Each upload appears in the list with its summary for easy review. New uploads show a temporary `Processing...` placeholder while the summary is generated. Any errors are shown next to the list.
 If available, the grade, extracted student name and date, mastery percentage and feedback also display under each summary.


### PR DESCRIPTION
## Summary
- extract text from PDF files before sending to the LLM
- send the rendered first page image with the extracted text
- document how PDF uploads are processed

## Testing
- `pnpm --dir app run lint`
- `pnpm --dir app run typecheck`
- `pnpm --dir app test`
- `pnpm --dir app test:e2e`
- `pnpm --dir app build`


------
https://chatgpt.com/codex/tasks/task_e_686ddd5fafd0832b9a8ffd133ecbae75