### PR TITLE
Implement student coverage API route

### DIFF
--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -17970,7 +17970,9 @@ snapshots:
       pretty-format: 24.9.0
       throat: 4.1.0
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   jest-leak-detector@24.9.0:
     dependencies:

--- a/app/src/app/api/students/[id]/curriculum-coverage/route.ts
+++ b/app/src/app/api/students/[id]/curriculum-coverage/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/db';
+import { teacherStudents, topicDags } from '@/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/authOptions';
+import { calculateCoverage } from '@/curriculumCoverage/calculateCoverage';
+
+const db = getDb();
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const session = await getServerSession(authOptions);
+  const teacherId = (session?.user as { id?: string } | undefined)?.id;
+  if (!teacherId) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const [row] = await db
+    .select({ topicDagId: teacherStudents.topicDagId, graph: topicDags.graph })
+    .from(teacherStudents)
+    .leftJoin(topicDags, eq(topicDags.id, teacherStudents.topicDagId))
+    .where(and(eq(teacherStudents.teacherId, teacherId), eq(teacherStudents.studentId, id)));
+
+  if (!row || !row.topicDagId || !row.graph) {
+    return NextResponse.json({ coverage: {} });
+  }
+
+  const graph = JSON.parse(row.graph);
+  const coverage = await calculateCoverage(id, graph);
+  return NextResponse.json({ coverage });
+}

--- a/app/src/components/GraphWithTooltips.tsx
+++ b/app/src/components/GraphWithTooltips.tsx
@@ -31,9 +31,11 @@ export function GraphWithTooltips({ graph }: { graph: Graph }) {
     }
   }, [graph])
 
+  const chart = graphToMermaid(graph, { htmlLabels: true })
+
   return (
     <div ref={ref}>
-      <Mermaid chart={graphToMermaid(graph, { htmlLabels: true })} config={{ securityLevel: 'loose' }} />
+      <Mermaid key={chart} chart={chart} config={{ securityLevel: 'loose' }} />
     </div>
   )
 }

--- a/app/src/components/StudentCurriculum.test.tsx
+++ b/app/src/components/StudentCurriculum.test.tsx
@@ -25,6 +25,10 @@ function mockStudent(topicDagId: string | null) {
   })
 }
 
+function mockCoverage() {
+  mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ coverage: {} }) })
+}
+
 function mockDags() {
   mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ dags: [] }) })
 }
@@ -37,6 +41,7 @@ describe('StudentCurriculum', () => {
   it('shows selector when no curriculum', async () => {
     mockStudent(null)
     mockDags()
+    mockCoverage()
     render(
       <I18nProvider lng="en">
         <StudentCurriculum studentId="s1" />
@@ -49,6 +54,7 @@ describe('StudentCurriculum', () => {
   it('shows graph when curriculum set', async () => {
     mockStudent('d1')
     mockDags()
+    mockCoverage()
     render(
       <I18nProvider lng="en">
         <StudentCurriculum studentId="s1" />
@@ -60,6 +66,7 @@ describe('StudentCurriculum', () => {
   it('allows changing curriculum', async () => {
     mockStudent('d1')
     mockDags()
+    mockCoverage()
     render(
       <I18nProvider lng="en">
         <StudentCurriculum studentId="s1" />

--- a/app/src/curriculumCoverage/calculateCoverage.test.ts
+++ b/app/src/curriculumCoverage/calculateCoverage.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { calculateCoverage } from './calculateCoverage';
+import type { Graph } from '@/graphSchema';
+
+vi.mock('@/db', () => {
+  const rows = [
+    { id: 'w1', masteryPercent: 100 },
+    { id: 'w2', masteryPercent: 50 },
+  ];
+  const from = vi.fn(() => ({ where: vi.fn().mockResolvedValue(rows) }));
+  const select = vi.fn(() => ({ from }));
+  const db = { select };
+  const sqlite = {
+    prepare: vi.fn(() => ({ get: vi.fn((t:string) => ({ id: t })) })),
+    transaction: vi.fn(() => vi.fn()),
+  };
+  return { getDb: () => db, getSqlite: () => sqlite };
+});
+
+vi.mock('@/db/embeddings', () => ({
+  getWorkVector: vi.fn((id: string) => (id === 'w1' ? [1,0] : [0,1])),
+  getTagVector: vi.fn((id: string) =>
+    id === 'a' ? [1,0] : id === 'b' ? [0,1] : [1,1]
+  ),
+}));
+
+describe('calculateCoverage', () => {
+  it('computes coverage from work vectors', async () => {
+    const graph: Graph = {
+      nodes: [
+        { id: 'n1', label: 'N1', desc: '', tags: ['a'], prereq: [] },
+        { id: 'n2', label: 'N2', desc: '', tags: ['b', 'c'], prereq: [] },
+      ],
+      edges: [],
+    };
+    const coverage = await calculateCoverage('s1', graph);
+    expect(coverage.n1).toBe(100);
+    expect(coverage.n2).toBe(50);
+  });
+});

--- a/app/src/curriculumCoverage/calculateCoverage.ts
+++ b/app/src/curriculumCoverage/calculateCoverage.ts
@@ -1,0 +1,56 @@
+import { getDb, getSqlite } from '@/db';
+import { uploadedWork } from '@/db/schema';
+import { eq } from 'drizzle-orm';
+import { getTagVector, getWorkVector } from '@/db/embeddings';
+import type { Graph } from '@/graphSchema';
+
+function similarity(a: number[], b: number[]): number {
+  const len = Math.min(a.length, b.length);
+  let sum = 0;
+  for (let i = 0; i < len; i++) {
+    const diff = a[i] - b[i];
+    sum += diff * diff;
+  }
+  const dist = Math.sqrt(sum);
+  return 1 / (1 + dist);
+}
+
+export async function calculateCoverage(studentId: string, dag: Graph): Promise<Record<string, number>> {
+  const db = getDb();
+  const sqlite = getSqlite();
+  const rows = await db
+    .select({ id: uploadedWork.id, masteryPercent: uploadedWork.masteryPercent })
+    .from(uploadedWork)
+    .where(eq(uploadedWork.studentId, studentId));
+
+  const works = rows
+    .filter((r) => r.masteryPercent !== null)
+    .map((r) => {
+      const vec = getWorkVector(r.id) || [];
+      return { vector: vec, weight: (r.masteryPercent as number) / 100 };
+    })
+    .filter((w) => w.vector.length);
+
+  const tagStmt = sqlite.prepare('SELECT id FROM tag WHERE text = ?');
+  const coverage: Record<string, number> = {};
+
+  for (const node of dag.nodes) {
+    const scores: number[] = [];
+    for (const tag of node.tags) {
+      const idRow = tagStmt.get(tag) as { id?: string } | undefined;
+      if (!idRow?.id) continue;
+      const tagVec = getTagVector(idRow.id);
+      if (!tagVec) continue;
+      let best = 0;
+      for (const work of works) {
+        const score = similarity(tagVec, work.vector) * work.weight;
+        if (score > best) best = score;
+      }
+      scores.push(best);
+    }
+    const avg = scores.length ? scores.reduce((a, b) => a + b, 0) / scores.length : 0;
+    coverage[node.id] = Math.round(avg * 100);
+  }
+
+  return coverage;
+}

--- a/app/tests/e2e/curriculumCoverage.test.ts
+++ b/app/tests/e2e/curriculumCoverage.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import { GET as getCoverage } from '@/app/api/students/[id]/curriculum-coverage/route';
+import { getServerSession } from 'next-auth';
+import { NextRequest } from 'next/server';
+
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }));
+vi.mock('@/authOptions', () => ({ authOptions: {} }));
+vi.mock('@/curriculumCoverage/calculateCoverage', () => ({
+  calculateCoverage: vi.fn().mockResolvedValue({ n1: 75 })
+}));
+vi.mock('@/db', () => {
+  const where = vi.fn().mockResolvedValue([
+    { topicDagId: 'd1', graph: JSON.stringify({ nodes: [], edges: [] }) }
+  ]);
+  const leftJoin = vi.fn(() => ({ where }));
+  const innerJoin = vi.fn(() => ({ leftJoin }));
+  const from = vi.fn(() => ({ innerJoin, leftJoin, where }));
+  const select = vi.fn(() => ({ from }));
+  const db = { select };
+  const sqlite = { prepare: vi.fn(), transaction: vi.fn() };
+  return { getDb: () => db, getSqlite: () => sqlite };
+});
+
+describe('student coverage API', () => {
+  it('requires authentication', async () => {
+    (getServerSession as unknown as Mock).mockResolvedValue(null);
+    const req = new NextRequest(new Request('http://localhost'));
+    const res = await getCoverage(req, { params: Promise.resolve({ id: 's1' }) });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns coverage data', async () => {
+    (getServerSession as unknown as Mock).mockResolvedValue({ user: { id: 't1' } });
+    const req = new NextRequest(new Request('http://localhost'));
+    const res = await getCoverage(req, { params: Promise.resolve({ id: 's1' }) });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.coverage.n1).toBe(75);
+  });
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,4 @@ This directory contains usage guides for Choose Your Own Curriculum. Each file f
 - [My Curriculums](usage/my_curriculums.md)
 - [Student Progress](usage/student_progress.md)
 - [Tag Generation](usage/tag_generation.md)
+- [Curriculum Coverage](usage/curriculum_coverage.md)

--- a/docs/usage/curriculum_coverage.md
+++ b/docs/usage/curriculum_coverage.md
@@ -1,0 +1,10 @@
+# Curriculum Coverage
+
+The application estimates how well a student's uploaded work covers each node of a curriculum.
+All uploaded work with a non-null `masteryPercent` is embedded and compared
+against the tag embeddings for each DAG node. For every node tag the highest
+similarity score across the student's work is multiplied by the work's
+`masteryPercent` and averaged to produce a coverage percentage for that node.
+
+When viewing a student's curriculum the graph displays these percentages after
+each node label so teachers can quickly spot areas that need more practice.


### PR DESCRIPTION
## Summary
- add coverage endpoint with path `/api/students/[id]/curriculum-coverage`
- compute curriculum coverage for a student and display values on graph nodes
- ensure mermaid graph re-renders when coverage changes

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run test:e2e`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_686de14a00d8832bb3fea1e1bd69eb4d