### PR TITLE
Implement mastery threshold for coverage

### DIFF
--- a/app/drizzle/0010_friendly_joystick.sql
+++ b/app/drizzle/0010_friendly_joystick.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `teacher_student` ADD `coverageMasteryThreshold` real DEFAULT 0 NOT NULL;--> statement-breakpoint
+

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -71,5 +71,12 @@
       "when": 1752028889696,
       "tag": "0009_eminent_marvel_apes",
       "breakpoints": true
-    }
-  ]}
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1752069881007,
+      "tag": "0010_friendly_joystick",
+      "breakpoints": true
+    }  ]
+}

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -17970,9 +17970,7 @@ snapshots:
       pretty-format: 24.9.0
       throat: 4.1.0
     transitivePeerDependencies:
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   jest-leak-detector@24.9.0:
     dependencies:

--- a/app/src/app/api/students/[id]/curriculum-coverage/route.ts
+++ b/app/src/app/api/students/[id]/curriculum-coverage/route.ts
@@ -19,7 +19,11 @@ export async function GET(
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
   const [row] = await db
-    .select({ topicDagId: teacherStudents.topicDagId, graph: topicDags.graph })
+    .select({
+      topicDagId: teacherStudents.topicDagId,
+      graph: topicDags.graph,
+      threshold: teacherStudents.coverageMasteryThreshold,
+    })
     .from(teacherStudents)
     .leftJoin(topicDags, eq(topicDags.id, teacherStudents.topicDagId))
     .where(and(eq(teacherStudents.teacherId, teacherId), eq(teacherStudents.studentId, id)));
@@ -29,6 +33,6 @@ export async function GET(
   }
 
   const graph = JSON.parse(row.graph);
-  const coverage = await calculateCoverage(id, graph);
+  const coverage = await calculateCoverage(id, graph, row.threshold);
   return NextResponse.json({ coverage });
 }

--- a/app/src/app/api/students/[id]/route.ts
+++ b/app/src/app/api/students/[id]/route.ts
@@ -26,6 +26,7 @@ export async function GET(
       name: students.name,
       email: students.email,
       topicDagId: teacherStudents.topicDagId,
+      coverageMasteryThreshold: teacherStudents.coverageMasteryThreshold,
       topics: topicDags.topics,
       graph: topicDags.graph,
     })
@@ -43,6 +44,7 @@ export async function GET(
       name: row.name,
       email: row.email,
       topicDagId: row.topicDagId,
+      coverageMasteryThreshold: row.coverageMasteryThreshold,
       topics: row.topics ? JSON.parse(row.topics) : null,
       graph: row.graph ? JSON.parse(row.graph) : null,
     },
@@ -69,9 +71,12 @@ export async function PUT(
   }
   const updateSchema = studentFieldsSchema
     .partial()
-    .extend({ topicDagId: z.string().nullable().optional() })
+    .extend({
+      topicDagId: z.string().nullable().optional(),
+      coverageMasteryThreshold: z.number().optional(),
+    })
   const data = updateSchema.parse(await req.json())
-  const { name, email, topicDagId } = data
+  const { name, email, topicDagId, coverageMasteryThreshold } = data
   const studentValues: {
     name?: string
     email?: string | null
@@ -96,6 +101,12 @@ export async function PUT(
     await db
       .update(teacherStudents)
       .set({ topicDagId: topicDagId || null })
+      .where(and(eq(teacherStudents.teacherId, teacherId), eq(teacherStudents.studentId, id)))
+  }
+  if (coverageMasteryThreshold !== undefined) {
+    await db
+      .update(teacherStudents)
+      .set({ coverageMasteryThreshold })
       .where(and(eq(teacherStudents.teacherId, teacherId), eq(teacherStudents.studentId, id)))
   }
   return NextResponse.json({ ok: true })

--- a/app/src/app/api/students/route.ts
+++ b/app/src/app/api/students/route.ts
@@ -43,6 +43,6 @@ export async function POST(req: NextRequest) {
     .returning({ id: students.id })
   await db
     .insert(teacherStudents)
-    .values({ teacherId, studentId: id })
+    .values({ teacherId, studentId: id, coverageMasteryThreshold: 0 })
   return NextResponse.json({ id })
 }

--- a/app/src/app/students/[id]/page.tsx
+++ b/app/src/app/students/[id]/page.tsx
@@ -2,6 +2,10 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/authOptions'
 import { StudentCurriculum } from '@/components/StudentCurriculum'
 import { UploadedWorkList } from '@/components/UploadedWorkList'
+import { CoverageThresholdInput } from '@/components/CoverageThresholdInput'
+import { getDb } from '@/db'
+import { teacherStudents } from '@/db/schema'
+import { eq, and } from 'drizzle-orm'
 import { initI18n } from '@/i18n'
 
 export default async function StudentProgressPage({
@@ -21,9 +25,16 @@ export default async function StudentProgressPage({
     )
   }
   const { id } = await params
+  const db = getDb()
+  const [row] = await db
+    .select({ threshold: teacherStudents.coverageMasteryThreshold })
+    .from(teacherStudents)
+    .where(and(eq(teacherStudents.teacherId, userId), eq(teacherStudents.studentId, id)))
+  const threshold = row?.threshold ?? 0
   return (
     <div style={{ padding: '2rem' }}>
       <h1>{i18n.t('studentProgress')}</h1>
+      <CoverageThresholdInput studentId={id} initial={threshold} />
       <StudentCurriculum studentId={id} />
       <UploadedWorkList studentId={id} />
     </div>

--- a/app/src/components/CoverageThresholdInput.tsx
+++ b/app/src/components/CoverageThresholdInput.tsx
@@ -1,0 +1,42 @@
+'use client'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { css } from '@/styled-system/css'
+import { Tooltip } from './Tooltip'
+import { InfoIcon } from './InfoIcon'
+
+export function CoverageThresholdInput({ studentId, initial }: { studentId: string; initial: number }) {
+  const { t } = useTranslation()
+  const [value, setValue] = useState(String(initial))
+
+  const save = async (val: string) => {
+    const num = Number(val) || 0
+    setValue(val)
+    await fetch(`/api/students/${studentId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ coverageMasteryThreshold: num }),
+    })
+    window.dispatchEvent(new Event('coverageThresholdChanged'))
+  }
+
+  return (
+    <label className={css({ display: 'flex', alignItems: 'center', gap: '1', marginBottom: '1rem' })}>
+      {t('coverageThreshold')}
+      <Tooltip content={t('coverageThresholdInfo')}>
+        <span className={css({ color: 'blue.500', cursor: 'pointer' })}>
+          <InfoIcon />
+        </span>
+      </Tooltip>
+      <input
+        type="number"
+        min="0"
+        max="100"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={(e) => save(e.target.value)}
+        className={css({ width: '12' })}
+      />
+    </label>
+  )
+}

--- a/app/src/components/GraphWithTooltips.stories.tsx
+++ b/app/src/components/GraphWithTooltips.stories.tsx
@@ -16,5 +16,6 @@ export const Default = {
       ],
       edges: [['a', 'b']],
     },
+    styles: { a: 'fill:#ffd700,color:#000' },
   },
 }

--- a/app/src/components/GraphWithTooltips.tsx
+++ b/app/src/components/GraphWithTooltips.tsx
@@ -6,7 +6,13 @@ import type { Graph } from '@/graphSchema'
 import { graphToMermaid } from '@/graphToMermaid'
 import { Tooltip } from './Tooltip'
 
-export function GraphWithTooltips({ graph }: { graph: Graph }) {
+export function GraphWithTooltips({
+  graph,
+  styles = {},
+}: {
+  graph: Graph
+  styles?: Record<string, string>
+}) {
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -31,7 +37,10 @@ export function GraphWithTooltips({ graph }: { graph: Graph }) {
     }
   }, [graph])
 
-  const chart = graphToMermaid(graph, { htmlLabels: true })
+  const styleLines = Object.entries(styles)
+    .map(([id, style]) => `style ${id} ${style}`)
+    .join('\n')
+  const chart = `${graphToMermaid(graph, { htmlLabels: true })}\n${styleLines}`
 
   return (
     <div ref={ref}>

--- a/app/src/components/InfoIcon.tsx
+++ b/app/src/components/InfoIcon.tsx
@@ -1,0 +1,9 @@
+'use client'
+export function InfoIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" width="1em" height="1em" {...props}>
+      <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" strokeWidth="2" />
+      <text x="12" y="16" textAnchor="middle" fontSize="12" fill="currentColor" fontFamily="sans-serif">i</text>
+    </svg>
+  );
+}

--- a/app/src/components/StudentCurriculum.tsx
+++ b/app/src/components/StudentCurriculum.tsx
@@ -61,6 +61,13 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
     }
   }
 
+  useEffect(() => {
+    const handler = () => loadCoverage()
+    window.addEventListener('coverageThresholdChanged', handler)
+    return () => window.removeEventListener('coverageThresholdChanged', handler)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const save = async () => {
     await fetch(`/api/students/${studentId}`, {
       method: 'PUT',

--- a/app/src/components/StudentCurriculum.tsx
+++ b/app/src/components/StudentCurriculum.tsx
@@ -14,6 +14,7 @@ interface StudentData {
   topicDagId: string | null
   topics: string[]
   graph: Graph | null
+  threshold: number
 }
 
 export function StudentCurriculum({ studentId }: { studentId: string }) {
@@ -22,6 +23,8 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
   const [selected, setSelected] = useState('')
   const [editing, setEditing] = useState(false)
   const [coverage, setCoverage] = useState<Record<string, number> | null>(null)
+  const [styles, setStyles] = useState<Record<string, string>>({})
+  const [currentTopics, setCurrentTopics] = useState<string[]>([])
   const { t } = useTranslation()
 
   const load = async () => {
@@ -32,6 +35,7 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
           topicDagId: string | null
           topics: string[] | null
           graph: Graph | null
+          coverageMasteryThreshold: number
         }
       }
       const s = json.student
@@ -39,6 +43,7 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
         topicDagId: s.topicDagId,
         topics: s.topics || [],
         graph: s.graph,
+        threshold: s.coverageMasteryThreshold ?? 0,
       })
       setSelected(s.topicDagId || '')
     }
@@ -62,7 +67,10 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
   }
 
   useEffect(() => {
-    const handler = () => loadCoverage()
+    const handler = () => {
+      loadCoverage()
+      load()
+    }
     window.addEventListener('coverageThresholdChanged', handler)
     return () => window.removeEventListener('coverageThresholdChanged', handler)
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -83,6 +91,36 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
     loadDags()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [studentId])
+
+  useEffect(() => {
+    if (!data?.graph || !coverage) return
+    const threshold = data.threshold
+    const mastered = new Set(
+      data.graph.nodes
+        .filter((n) => (coverage[n.id] ?? 0) >= threshold)
+        .map((n) => n.id),
+    )
+    const current = new Set<string>()
+    for (const [from, to] of data.graph.edges) {
+      if (mastered.has(from) && !mastered.has(to)) current.add(to)
+    }
+    const future = new Set<string>()
+    for (const [from, to] of data.graph.edges) {
+      if (current.has(from) && !mastered.has(to) && !current.has(to)) {
+        future.add(to)
+      }
+    }
+    const styleMap: Record<string, string> = {}
+    mastered.forEach((id) => (styleMap[id] = 'fill:#ffd700,color:#000'))
+    current.forEach((id) => (styleMap[id] = 'fill:#38a169,color:#fff'))
+    future.forEach((id) => (styleMap[id] = 'fill:#e53e3e,color:#fff'))
+    setStyles(styleMap)
+    setCurrentTopics(
+      Array.from(current).map(
+        (id) => data.graph!.nodes.find((n) => n.id === id)?.label || id,
+      ),
+    )
+  }, [coverage, data?.graph, data?.threshold])
 
   useEffect(() => {
     loadCoverage()
@@ -143,7 +181,13 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
                     : n.label,
               })),
             }}
+            styles={styles}
           />
+        </div>
+      )}
+      {currentTopics.length > 0 && (
+        <div style={{ marginTop: '0.5rem' }}>
+          <strong>{t('currentTopics')}:</strong> {currentTopics.join(', ')}
         </div>
       )}
       <div style={{ marginTop: '0.5rem' }}>

--- a/app/src/curriculumCoverage/calculateCoverage.test.ts
+++ b/app/src/curriculumCoverage/calculateCoverage.test.ts
@@ -37,4 +37,15 @@ describe('calculateCoverage', () => {
     expect(coverage.n1).toBe(100);
     expect(coverage.n2).toBe(50);
   });
+
+  it('ignores work below mastery threshold', async () => {
+    const graph: Graph = {
+      nodes: [
+        { id: 'n1', label: 'N1', desc: '', tags: ['b'], prereq: [] },
+      ],
+      edges: [],
+    };
+    const coverage = await calculateCoverage('s1', graph, 75);
+    expect(coverage.n1).toBe(41);
+  });
 });

--- a/app/src/curriculumCoverage/calculateCoverage.ts
+++ b/app/src/curriculumCoverage/calculateCoverage.ts
@@ -15,7 +15,11 @@ function similarity(a: number[], b: number[]): number {
   return 1 / (1 + dist);
 }
 
-export async function calculateCoverage(studentId: string, dag: Graph): Promise<Record<string, number>> {
+export async function calculateCoverage(
+  studentId: string,
+  dag: Graph,
+  threshold = Number(process.env.COVERAGE_MASTERY_THRESHOLD ?? '0'),
+): Promise<Record<string, number>> {
   const db = getDb();
   const sqlite = getSqlite();
   const rows = await db
@@ -24,7 +28,9 @@ export async function calculateCoverage(studentId: string, dag: Graph): Promise<
     .where(eq(uploadedWork.studentId, studentId));
 
   const works = rows
-    .filter((r) => r.masteryPercent !== null)
+    .filter(
+      (r) => r.masteryPercent !== null && (r.masteryPercent as number) > threshold
+    )
     .map((r) => {
       const vec = getWorkVector(r.id) || [];
       return { vector: vec, weight: (r.masteryPercent as number) / 100 };

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -89,6 +89,9 @@ export const teacherStudents = sqliteTable(
       .notNull()
       .references(() => students.id, { onDelete: 'cascade' }),
     topicDagId: text('topicDagId').references(() => topicDags.id),
+    coverageMasteryThreshold: real('coverageMasteryThreshold')
+      .notNull()
+      .default(0),
   },
   (ts) => ({
     pk: primaryKey(ts.teacherId, ts.studentId),

--- a/app/src/locales/en/common.json
+++ b/app/src/locales/en/common.json
@@ -61,5 +61,8 @@
   "masteryPercent": "Mastery",
   "studentName": "Student Name",
   "dateOfWork": "Date of Work",
-  "feedback": "Feedback"
+  "feedback": "Feedback",
+  "coverageThreshold": "Coverage Threshold",
+  "coverageThresholdInfo": "Only work above this mastery percentage counts toward coverage.",
+  "currentTopics": "Current Topics"
 }

--- a/app/src/locales/es/common.json
+++ b/app/src/locales/es/common.json
@@ -56,5 +56,8 @@
   "saveGraph": "Guardar gráfico",
   "saved": "Guardado",
   "cancel": "Cancelar",
-  "change": "Cambiar currículo"
+  "change": "Cambiar currículo",
+  "coverageThreshold": "Umbral de cobertura",
+  "coverageThresholdInfo": "Solo el trabajo por encima de este porcentaje de dominio cuenta para la cobertura.",
+  "currentTopics": "Temas actuales"
 }

--- a/app/src/locales/fr/common.json
+++ b/app/src/locales/fr/common.json
@@ -56,5 +56,8 @@
   "saveGraph": "Enregistrer le graphique",
   "saved": "Enregistré",
   "cancel": "Annuler",
-  "change": "Modifier le curriculum"
+  "change": "Modifier le curriculum",
+  "coverageThreshold": "Seuil de couverture",
+  "coverageThresholdInfo": "Seul le travail dépassant ce pourcentage de maîtrise est pris en compte dans la couverture.",
+  "currentTopics": "Sujets actuels"
 }

--- a/docs/usage/curriculum_coverage.md
+++ b/docs/usage/curriculum_coverage.md
@@ -13,3 +13,7 @@ the chosen percentage is ignored when computing coverage.
 
 When viewing a student's curriculum the graph displays these percentages after
 each node label so teachers can quickly spot areas that need more practice.
+Nodes with coverage above the threshold appear in gold while their immediate
+successors are highlighted in green as *current* topics. Topics following those
+current nodes show up in red as *future* topics. The current topics are also
+listed below the graph.

--- a/docs/usage/curriculum_coverage.md
+++ b/docs/usage/curriculum_coverage.md
@@ -1,10 +1,15 @@
 # Curriculum Coverage
 
 The application estimates how well a student's uploaded work covers each node of a curriculum.
-All uploaded work with a non-null `masteryPercent` is embedded and compared
+All uploaded work with a non-null `masteryPercent` above the
+`COVERAGE_MASTERY_THRESHOLD` environment variable (default `0`) is embedded and compared
 against the tag embeddings for each DAG node. For every node tag the highest
 similarity score across the student's work is multiplied by the work's
 `masteryPercent` and averaged to produce a coverage percentage for that node.
+
+Teachers can override this threshold for each student on the progress page using
+the **Coverage Threshold** field (look for the blue **i** tooltip). Work below
+the chosen percentage is ignored when computing coverage.
 
 When viewing a student's curriculum the graph displays these percentages after
 each node label so teachers can quickly spot areas that need more practice.


### PR DESCRIPTION
## Summary
- ignore uploads with low mastery when calculating curriculum coverage
- allow teachers to configure the threshold on each student's progress page
- add coverage threshold tooltip and icon
- regenerate database schema and migration
- document teacher-configurable threshold

## Testing
- `pnpm run format` *(fails: No files were processed)*
- `pnpm run lint`
- `pnpm run lint:md`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686dee9dda90832b9273c2e97ab93cf9