### PR TITLE
Add OpenAI key placeholder to example env

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -7,3 +7,4 @@ SMTP_USER=user
 SMTP_PASS=pass
 SMTP_FROM=noreply@example.com
 EMBEDDING_MODEL=text-embedding-3-small
+OPENAI_API_KEY=your-api-key


### PR DESCRIPTION
## Summary
- update `.env.example` with `OPENAI_API_KEY` placeholder

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686ecd5aa9e8832ba05082105dbe9665