### PR TITLE
Refactor inline styles to Panda CSS

### DIFF
--- a/app/src/app/login/page.tsx
+++ b/app/src/app/login/page.tsx
@@ -2,24 +2,17 @@
 
 import { signIn } from 'next-auth/react';
 import { useTranslation } from 'react-i18next';
-const styles = {
-  container: {
-    padding: '2rem',
-    textAlign: 'center' as const,
-  },
-  button: {
-    padding: '0.5rem 1rem',
-    fontSize: '1rem',
-    cursor: 'pointer',
-  },
-};
+import { css } from '@/styled-system/css';
 
 export default function LoginPage() {
   const { t } = useTranslation();
   return (
-    <div style={styles.container}>
+    <div className={css({ padding: '2rem', textAlign: 'center' })}>
       <h1>{t('logIn')}</h1>
-      <button style={styles.button} onClick={() => signIn('email', { callbackUrl: '/' })}>
+      <button
+        className={css({ padding: '0.5rem 1rem', fontSize: '1rem', cursor: 'pointer' })}
+        onClick={() => signIn('email', { callbackUrl: '/' })}
+      >
         {t('signInWithEmail')}
       </button>
     </div>

--- a/app/src/app/students/[id]/page.tsx
+++ b/app/src/app/students/[id]/page.tsx
@@ -7,6 +7,7 @@ import { getDb } from '@/db'
 import { teacherStudents } from '@/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { initI18n } from '@/i18n'
+import { css } from '@/styled-system/css'
 
 export default async function StudentProgressPage({
   params,
@@ -18,7 +19,7 @@ export default async function StudentProgressPage({
   const userId = (session?.user as { id?: string } | undefined)?.id
   if (!userId) {
     return (
-      <div style={{ padding: '2rem' }}>
+      <div className={css({ padding: '2rem' })}>
         <h1>{i18n.t('studentProgress')}</h1>
         <p>{i18n.t('signInProgress')}</p>
       </div>
@@ -32,7 +33,7 @@ export default async function StudentProgressPage({
     .where(and(eq(teacherStudents.teacherId, userId), eq(teacherStudents.studentId, id)))
   const threshold = row?.threshold ?? 0
   return (
-    <div style={{ padding: '2rem' }}>
+    <div className={css({ padding: '2rem' })}>
       <h1>{i18n.t('studentProgress')}</h1>
       <CoverageThresholdInput studentId={id} initial={threshold} />
       <StudentCurriculum studentId={id} />

--- a/app/src/components/StudentCurriculum.tsx
+++ b/app/src/components/StudentCurriculum.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Graph } from '@/graphSchema'
 import { GraphWithTooltips } from './GraphWithTooltips'
+import { css } from '@/styled-system/css'
 
 interface Dag {
   id: string
@@ -131,7 +132,7 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
 
   if (!data.topicDagId || editing) {
     return (
-      <div style={{ marginBottom: '1rem' }}>
+      <div className={css({ marginBottom: '1rem' })}>
         <label>
           {t('curriculum')}
           <select
@@ -146,7 +147,11 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
             ))}
           </select>
         </label>
-        <button onClick={save} disabled={!selected} style={{ marginLeft: '0.5rem' }}>
+        <button
+          onClick={save}
+          disabled={!selected}
+          className={css({ marginLeft: '0.5rem' })}
+        >
           {t('save')}
         </button>
         {data.topicDagId && (
@@ -155,7 +160,7 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
               setEditing(false)
               setSelected(data.topicDagId || '')
             }}
-            style={{ marginLeft: '0.5rem' }}
+            className={css({ marginLeft: '0.5rem' })}
           >
             {t('cancel')}
           </button>
@@ -165,11 +170,11 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
   }
 
   return (
-    <div style={{ marginBottom: '1rem' }}>
+    <div className={css({ marginBottom: '1rem' })}>
       <h2>{t('curriculum')}</h2>
       <div>{data.topics.join(', ')}</div>
       {data.graph && (
-        <div style={{ marginTop: '1rem' }}>
+        <div className={css({ marginTop: '1rem' })}>
           <GraphWithTooltips
             graph={{
               ...data.graph,
@@ -186,11 +191,11 @@ export function StudentCurriculum({ studentId }: { studentId: string }) {
         </div>
       )}
       {currentTopics.length > 0 && (
-        <div style={{ marginTop: '0.5rem' }}>
+        <div className={css({ marginTop: '0.5rem' })}>
           <strong>{t('currentTopics')}:</strong> {currentTopics.join(', ')}
         </div>
       )}
-      <div style={{ marginTop: '0.5rem' }}>
+      <div className={css({ marginTop: '0.5rem' })}>
         <button
           onClick={() => {
             setSelected('')


### PR DESCRIPTION
## Summary
- refactor login page to use Panda CSS
- switch StudentCurriculum to Panda CSS classes
- update student page styling with Panda CSS

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686ecd1af47c832b90b5144fd1891d5e