### PR TITLE
Update node imports to use protocol

### DIFF
--- a/app/src/auth/authorize.ts
+++ b/app/src/auth/authorize.ts
@@ -1,5 +1,5 @@
 import { newEnforcer } from 'casbin';
-import path from 'path';
+import path from 'node:path';
 
 let enforcerPromise: ReturnType<typeof newEnforcer> | null = null;
 

--- a/app/src/db/index.ts
+++ b/app/src/db/index.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 import Database from 'better-sqlite3';
 import type { Database as SqliteDatabase } from 'better-sqlite3';
 import { drizzle, type BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 
 export default defineConfig({
   plugins: [react()],

--- a/app/vitest.e2e.config.ts
+++ b/app/vitest.e2e.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- use `node:` protocol for fs, path, and resolve imports

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run test:e2e`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ecd35e638832bb11a50081823ba42