### PR TITLE
Fix biome format command

### DIFF
--- a/app/biome.json
+++ b/app/biome.json
@@ -9,7 +9,7 @@
     "ignoreUnknown": false
   },
   "formatter": {
-    "enabled": false,
+    "enabled": true,
     "indentStyle": "space",
     "indentWidth": 2
   },

--- a/app/src/components/UploadForm.test.tsx
+++ b/app/src/components/UploadForm.test.tsx
@@ -1,23 +1,25 @@
-import { render, fireEvent, screen } from '@testing-library/react'
-import { UploadForm } from './UploadForm'
-import I18nProvider from './I18nProvider'
-import '@testing-library/jest-dom'
+import { render, fireEvent, screen } from "@testing-library/react";
+import { UploadForm } from "./UploadForm";
+import I18nProvider from "./I18nProvider";
+import "@testing-library/jest-dom";
 
-vi.mock('next/navigation', () => ({ useRouter: () => ({}) }))
+vi.mock("next/navigation", () => ({ useRouter: () => ({}) }));
 
-describe('UploadForm', () => {
-  it('shows validation errors', async () => {
-    global.fetch = vi
-      .fn()
-      .mockResolvedValue({ ok: true, json: async () => ({ students: [] }) }) as unknown as typeof fetch
+describe("UploadForm", () => {
+  it("shows validation errors", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ students: [] }),
+    }) as unknown as typeof fetch;
     render(
       <I18nProvider lng="en">
         <UploadForm />
-      </I18nProvider>
-    )
-    fireEvent.submit(await screen.findByRole('button'))
-    expect(await screen.findByText('File is required')).toBeInTheDocument()
-    expect(await screen.findByText('Student ID is required')).toBeInTheDocument()
-  })
-
-})
+      </I18nProvider>,
+    );
+    fireEvent.submit(await screen.findByRole("button"));
+    expect(await screen.findByText("File is required")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Student ID is required"),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- enable the Biome formatter so `pnpm run format` works
- format the `UploadForm.test.tsx`

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686ece2b1b14832b8d8d3738c6987615